### PR TITLE
Included better prompting for Half Half OCE variants

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,12 +83,16 @@ iron:url@1.1.0
 jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
+lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.1.20
 mdg:validated-method@1.1.0
 mdg:validation-error@0.5.1
 meteor@1.8.6
 meteor-base@1.3.0
+meteorhacks:picker@1.0.3
+meteortesting:browser-tests@1.0.0
+meteortesting:mocha@1.0.0
 meteortoys:toykit@3.0.4
 minifier-css@1.3.1
 minifier-js@2.3.5

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,16 +83,12 @@ iron:url@1.1.0
 jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
-lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.1.20
 mdg:validated-method@1.1.0
 mdg:validation-error@0.5.1
 meteor@1.8.6
 meteor-base@1.3.0
-meteorhacks:picker@1.0.3
-meteortesting:browser-tests@1.0.0
-meteortesting:mocha@1.0.0
 meteortoys:toykit@3.0.4
 minifier-css@1.3.1
 minifier-js@2.3.5

--- a/imports/api/ImageUpload/server/publications.js
+++ b/imports/api/ImageUpload/server/publications.js
@@ -3,7 +3,7 @@ import { Images } from '../images.js';
 
 Meteor.publish('images.activeIncident', function (incidentId) {
   //console.log('subscribing to ImageUpload.activeIncident', incidentId);
-  return Images.find({ iid: incidentId });
+  return Images.find({ iid: incidentId }, { sort: { uploadedAt: 1 } } );
 });
 
 Meteor.publish('images.all', function () {

--- a/imports/api/Testing/createNewExperiences.js
+++ b/imports/api/Testing/createNewExperiences.js
@@ -27,6 +27,33 @@ Meteor.methods({
     Experiences.insert(exp);
     let incident = createIncidentFromExperience(exp);
     startRunningIncident(incident);
+  },
+  /** upsertDetector - general function to update or insert detectors through a Meteor RPC
+   *
+   * @param name [String] A key in CONSTANTS.DETECTORS object found in testingconstants.js
+   */
+  upsertDetector({name}) {
+    new SimpleSchema({
+      name: { type: String }
+    }).validate({name});
+
+    if (!(name in CONSTANTS.DETECTORS)) {
+      throw new Meteor.Error('upsertDetector.keynotfound',
+        `Detector by the name '${name}' was not found in CONSTANTS.DETECTORS`);
+    }
+
+    let {numberAffected, insertedId} = Detectors.upsert(
+      {
+        _id: CONSTANTS.DETECTORS[name]._id
+      }, {
+        $set : {
+          description: CONSTANTS.DETECTORS[name].description,
+          variables: CONSTANTS.DETECTORS[name].variables,
+          rules: CONSTANTS.DETECTORS[name].rules
+        }
+      }
+    );
+    console.log(`Method call to "upsertDetector"! numberAffected: ${numberAffected}, insertedId: ${insertedId}`);
   }
 });
 

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -831,6 +831,43 @@ let EXPERIENCES = {
       function: sendNotificationHalfHalf.toString()
     }]
   },
+  halfhalfEmbodiedMimicry: {
+    _id: Random.id(),
+    name: 'Body Mirror',
+    participateTemplate: 'halfhalfParticipate',
+    resultsTemplate: 'halfhalfResults',
+    contributionTypes: [{
+      needName: 'Hand Silhouette',
+      situation: {
+        detector: DETECTORS.sunny._id,
+        number: '1'
+      },
+      toPass: {
+        instruction: 'Take a photo, holding your hand towards the sky, covering the sun.',
+        exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-hands-in-front.jpg'
+      },
+      numberNeeded: 2,
+      notificationDelay: 1,
+    }, {
+      needName: 'I eat with my hands',
+      situation: {
+        detector: DETECTORS.grocery._id,
+        number: '1'
+      },
+      toPass: {
+        instruction: 'Take a photo, holding a fruit or vegetable outstretched with your hands.',
+        exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-holding-orange.jpg'
+      },
+      numberNeeded: 2,
+      notificationDelay: 90,
+    }],
+    description: 'With your environment as the shared canvas, pose your body to be the mirror image of a friend',
+    notificationText: 'Your situation made you available to participate in Body Mirror!',
+    callbacks: [{
+      trigger: 'cb.incidentFinished()',
+      function: sendNotificationHalfHalf.toString()
+    }]
+  },
   scavengerHunt: {
     _id: Random.id(),
     name: 'St. Patrick\'s Day Scavenger Hunt',
@@ -1097,8 +1134,8 @@ export const CONSTANTS = {
   'LOCATIONS': LOCATIONS,
   'USERS': USERS,
   // Comment out if you would like to only test specific experiences
-  // 'EXPERIENCES': (({ halfhalfAsynch }) => ({ halfhalfAsynch}))(EXPERIENCES),
-  'EXPERIENCES': EXPERIENCES,
+  'EXPERIENCES': (({ halfhalfEmbodiedMimicry }) => ({ halfhalfEmbodiedMimicry }))(EXPERIENCES),
+  // 'EXPERIENCES': EXPERIENCES,
   'DETECTORS': DETECTORS
 };
 

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -670,19 +670,18 @@ const createHalfHalf = function(
 
 
   let completedCallback = function(sub) {
-    console.log("a full need completed for half half travel!!!");
+    console.log("Another pair of halves completed a photo");
 
-    let otherSub = Submissions.findOne({
-      uid: {
-        $ne: sub.uid
-      },
+    let submissions = Submissions.find({
       iid: sub.iid,
       needName: sub.needName
-    });
+    }).fetch();
 
-    notify([sub.uid, otherSub.uid], sub.iid,
-      'A half half travel photo was completed!',
-      'See the two halves of an interdependent, visual story you created with someone else!',
+    let participants = submissions.map((submission) => { return submission.uid; });
+
+    notify(participants, sub.iid,
+      `Two people completed a half half photo`,
+      `See the results under ${sub.needName}`,
       '/apicustomresults/' + sub.iid + '/' + sub.eid);
   };
 
@@ -713,7 +712,7 @@ const createHalfHalf = function(
     };
 
     let callback = {
-      trigger: `cb.numberOfSubmissions("${need.needName}") === 2`,
+      trigger: `cb.numberOfSubmissions("${need.needName}") % 2`,
       function: completedCallback.toString(),
     };
     experience.contributionTypes.push(need);
@@ -746,11 +745,20 @@ let sendNotificationFoodFight = function (sub) {
   notify(uids, sub.iid, 'Wooh! Both participants have attacked each other with food pics', '', '/apicustomresults/' + sub.iid + '/' + sub.eid);
 };
 
-let sendNotificationHalfHalf = function (sub) {
-  let uids = Submissions.find({ iid: sub.iid }).fetch().map(function (x) {
-    return x.uid;
-  });
-  notify(uids, sub.iid, 'View your two halves, side-by-side!', '', '/apicustomresults/' + sub.iid + '/' + sub.eid);
+const sendNotificationTwoHalvesCompleted = function(sub) {
+  console.log("Another pair of halves completed a photo");
+
+  let submissions = Submissions.find({
+    iid: sub.iid,
+    needName: sub.needName
+  }).fetch();
+
+  let participants = submissions.map((submission) => { return submission.uid; });
+
+  notify(participants, sub.iid,
+    `Two people completed a half half photo`,
+    `See the results under ${sub.needName}`,
+    '/apicustomresults/' + sub.iid + '/' + sub.eid);
 };
 
 let EXPERIENCES = {
@@ -797,14 +805,14 @@ let EXPERIENCES = {
       toPass: {
         instruction: 'Take a photo of like Half Half Travel!'
       },
-      numberNeeded: 10,
+      numberNeeded: 50, // arbitrarily high for a study
       notificationDelay: 1,
     }],
     description: 'Create adventures that meet halfway! Ready to live in a parallel with someone else?',
     notificationText: 'Participate in Half Half Travel!',
     callbacks: [{
-      trigger: 'cb.incidentFinished()',
-      function: sendNotificationHalfHalf.toString()
+      trigger: 'cb.numberOfSubmissions("half half: daytime") % 2 === 0',
+      function: sendNotificationTwoHalvesCompleted.toString()
     }]
   },
   halfhalfNight: {
@@ -821,14 +829,14 @@ let EXPERIENCES = {
       toPass: {
         instruction: 'Take a photo of like Half Half Travel!'
       },
-      numberNeeded: 2,
+      numberNeeded: 50, // arbitrarily high for a study
       notificationDelay: 1, // no need to delay if its daytime outside
     }],
     description: 'Create adventures that meet halfway! Ready to live in a parallel with someone else?',
     notificationText: 'Participate in Half Half Travel!',
     callbacks: [{
-      trigger: 'cb.incidentFinished()',
-      function: sendNotificationHalfHalf.toString()
+      trigger: 'cb.numberOfSubmissions("half half: nighttime") % 2 === 0',
+      function: sendNotificationTwoHalvesCompleted.toString()
     }]
   },
   halfhalfEmbodiedMimicry: {
@@ -846,7 +854,7 @@ let EXPERIENCES = {
         instruction: 'Take a photo, holding your hand towards the sky, covering the sun.',
         exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-hands-in-front.jpg'
       },
-      numberNeeded: 2,
+      numberNeeded: 50,
       notificationDelay: 1,
     }, {
       needName: 'I eat with my hands',
@@ -858,14 +866,14 @@ let EXPERIENCES = {
         instruction: 'Take a photo, holding a fruit or vegetable outstretched with your hands.',
         exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-holding-orange.jpg'
       },
-      numberNeeded: 2,
+      numberNeeded: 50,
       notificationDelay: 90,
     }],
     description: 'With your environment as the shared canvas, pose your body to be the mirror image of a friend',
     notificationText: 'Your situation made you available to participate in Body Mirror!',
     callbacks: [{
-      trigger: 'cb.incidentFinished()',
-      function: sendNotificationHalfHalf.toString()
+      trigger: 'cb.number()',
+      function: sendNotificationTwoHalvesCompleted.toString()
     }]
   },
   scavengerHunt: {

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -89,9 +89,13 @@ let DETECTORS = {
   },
   library: {
     _id: '5LqfPRajiQRe9BwBT',
-    description: ' libaries,',
-    variables: ['var  libraries;'],
-    rules: [' libraries;']
+    description: 'libraries and other books',
+    variables: [
+      'var libraries;',
+      'var usedbooks;',
+      'var bookstores;'
+    ],
+    rules: ['(libraries || bookstores);']
   },
   gym: {
     _id: '3XqHN8A4EpCZRpegS',
@@ -227,7 +231,7 @@ let DETECTORS = {
       'var churches;',
       'var mosques;'
     ],
-    rules: ['(mini_golf || ((buddhist_temples || religiousschools) || ((synagogues || hindu_temples) || (weddingchappels || churches)))) || mosques);']
+    rules: ['((mini_golf || ((buddhist_temples || religiousschools) || ((synagogues || hindu_temples) || (weddingchappels || churches)))) || mosques);']
   },
   bar: {
     _id: '6urWtr6Tasohdb43u',
@@ -419,6 +423,62 @@ let DETECTORS = {
       'var martialarts;'
     ],
     rules: ['(((amateursportsteams || religiousschools) || ((physicaltherapy || fencing) || ((beachvolleyball || football) || tennis))) || ((boxing || kickboxing) || ((muaythai || gyms) || ((badminton || healthtrainers) || ((bootcamps || pilates) || ((trampoline || dancestudio) || ((cyclingclasses || cardioclasses) || ((barreclasses || sports_clubs) || ((active || weightlosscenters) || ((yoga || aerialfitness) || ((surfing || fitness) || (martialarts || circuittraininggyms)))))))))))) || ((boxing || kickboxing) || ((muaythai || gyms) || ((healthtrainers || poledancingclasses) || ((bootcamps || pilates) || ((dancestudio || brazilianjiujitsu) || ((cyclingclasses || cardioclasses) || ((barreclasses || intervaltraininggyms) || ((sports_clubs || weightlosscenters) || ((aerialfitness || communitycenters) || ((squash || surfing) || ((fitness || martialarts) || circuittraininggyms)))))))))));']
+  },
+  eating_japanese: {
+    _id: "vpP7boQqvLzxhDxjg",
+    description: "eating a japanese meal",
+    variables: [
+      "var sushi;",
+      "var japanese;",
+      "var tonkatsu;",
+      "var teppanyaki;",
+      "var tempura;",
+      "var ramen;",
+      "var izakaya;",
+      "var udon;"
+    ],
+    rules: ["(sushi || japanese) || ((tonkatsu || teppanyaki) || ((tempura || ramen) || (izakaya || udon)));"]
+  },
+  eating_with_chopsticks: {
+    _id: "5Ay2Ys9DAH2PcPS4a",
+    description: "eating with chopsticks",
+    variables: [
+      "var korean;",
+      "var hawaiian;",
+      "var japacurry;",
+      "var sushi;",
+      "var singaporean;",
+      "var hakka;",
+      "var laotian;",
+      "var cambodian;",
+      "var japanese;",
+      "var tonkatsu;",
+      "var chinese;",
+      "var taiwanese;",
+      "var vietnamese;",
+      "var indonesian;",
+      "var panasian;",
+      "var thai;",
+      "var noodles;",
+      "var hotpot;",
+      "var tcm;",
+      "var cantonese;",
+      "var asianfusion;",
+      "var dimsum;",
+      "var shanghainese;",
+      "var burmese;",
+      "var teppanyaki;",
+      "var tempura;",
+      "var szechuan;",
+      "var hkcafe;",
+      "var ramen;",
+      "var izakaya;",
+      "var malaysian;",
+      "var udon;"
+    ],
+    rules: [
+      "(((japacurry || sushi) || ((japanese || tonkatsu) || ((noodles || hotpot) || ((asianfusion || korean) || ((teppanyaki || tempura) || ((ramen || izakaya) || (malaysian || udon))))))) || (korean || hawaiian)) || (((singaporean || hakka) || ((chinese || taiwanese) || ((tcm || cantonese) || ((dimsum || shanghainese) || ((szechuan || hkcafe) || burmese))))) || ((laotian || cambodian) || ((vietnamese || indonesian) || (panasian || thai))));"
+    ]
   }
 };
 
@@ -492,7 +552,8 @@ function createStorytime() {
       '_id': detectorIds[i],
       'description': DETECTORS[place].description + "_storytime",
       'variables': newVars,
-      'rules': ['(' + DETECTORS[place].rules[0] + ' ) && !participatedInStorytime;']
+      // 'rules': ['(' + DETECTORS[place].rules[0] + ' ) && !participatedInStorytime;']
+      'rules': [`!participatedInStorytime && ${DETECTORS[place].rules[0]}`]
     };
 
     i++;
@@ -722,6 +783,149 @@ const createHalfHalf = function(
   return experience;
 };
 
+const halfhalfEmbodiedContributionTypes = function() {
+  return [{
+    needName: 'Hand Silhouette',
+    situation: {
+      detector: DETECTORS.sunny._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Take a photo, holding your hand towards the sky, covering the sun.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-hands-in-front.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 1,
+  }, {
+    needName: 'I eat with my hands',
+    situation: {
+      detector: DETECTORS.grocery._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Take a photo, holding a fruit or vegetable outstretched with your hands.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-holding-orange.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 90,
+  }, {
+    needName: 'Coffee Date',
+    situation: {
+      detector: DETECTORS.coffee._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Are you at a cafe? Take a photo, holding your cup, mug, or plate towards the center of the screen.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-cafe.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 60 * 4
+  }, {
+    needName: 'Raise a glass',
+    situation: {
+      detector: DETECTORS.bar._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'What are you drinking? Take a photo, while raising your glass or bottle in front of you.',
+      // exampleImage: TODO(rlouie): get image holding a glass / bottle, indoors. Maybe towards the lights in the bar
+    },
+    numberNeeded: 50,
+    notificationDelay: 60 * 10
+  }, {
+    needName: 'Itadakimasu (I humbly receive this meal)',
+    situation: {
+      detector: DETECTORS.eating_japanese._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Take a photo, while holding chopsticks in your hand, saying "Itadakimasu" which translates to "I humbly receive this meal"',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-itadakimasu.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 60 * 10
+  }, {
+    needName: 'Religious Architecture',
+    situation: {
+      detector: DETECTORS.castle._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Do you notice the details of religious buildings? Do so now, by outstretching your hand and pointing out of the elements that stick out to you most.',
+      // TODO(rlouie): take a photo for embodied mimicry of a building
+      // exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-visual-mimicry-religious.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 30
+  }, {
+    needName: 'Touch a sunset',
+    situation: {
+      detector: DETECTORS.sunset._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'What does the sunset look like where you are? Find a good view of the sunset. Then, take a photo, with your hands outstretched towards the sun.',
+    },
+    numberNeeded: 50,
+    notificationDelay: 1,
+  }, {
+    needName: 'Eating with Chopsticks',
+    situation: {
+      detector: DETECTORS.eating_with_chopsticks._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'What can you pick up using chopsticks? Take a photo of what you are eating, holding your chopsticks.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-holding-chopsticks.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 60 * 15
+  }, {
+    needName: 'Whats in your grocery basket',
+    situation: {
+      detector: DETECTORS.grocery._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'What are you planning on eating for the week? Take a photo holding up a favorite or essential item in your shopping basket or cart.',
+    },
+    numberNeeded: 50,
+    notificationDelay: 60 * 5
+  }, {
+    needName: 'filling up gas',
+    situation: {
+      detector: DETECTORS.gas_station._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'You must be filling up at the station! Take a photo of your hand holding the filling pump'
+    },
+    numberNeeded: 50,
+    notificationDelay: 60 * 2
+  }, {
+    needName: 'reading a book',
+    situation: {
+      detector: DETECTORS.library._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Sorry to interrupt your reading! Find the nearest book, and take a photo holding up the book to your face.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-book-face.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 60 * 10
+  }];
+};
+
+const createCallbacksForEmbodiedMimicry = function(contributionTypes) {
+  return contributionTypes.map((need) => {
+    return {
+      trigger: `cb.numberOfSubmissions(${need.needName}) % 2 === 0`,
+      function: sendNotificationTwoHalvesCompleted.toString()
+    };
+  });
+};
+
 let sendNotificationScavenger = function (sub) {
   let uids = Submissions.find({ iid: sub.iid }).fetch().map(function (x) {
     return x.uid;
@@ -844,37 +1048,10 @@ let EXPERIENCES = {
     name: 'Body Mirror',
     participateTemplate: 'halfhalfParticipate',
     resultsTemplate: 'halfhalfResults',
-    contributionTypes: [{
-      needName: 'Hand Silhouette',
-      situation: {
-        detector: DETECTORS.sunny._id,
-        number: '1'
-      },
-      toPass: {
-        instruction: 'Take a photo, holding your hand towards the sky, covering the sun.',
-        exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-hands-in-front.jpg'
-      },
-      numberNeeded: 50,
-      notificationDelay: 1,
-    }, {
-      needName: 'I eat with my hands',
-      situation: {
-        detector: DETECTORS.grocery._id,
-        number: '1'
-      },
-      toPass: {
-        instruction: 'Take a photo, holding a fruit or vegetable outstretched with your hands.',
-        exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-holding-orange.jpg'
-      },
-      numberNeeded: 50,
-      notificationDelay: 90,
-    }],
+    contributionTypes: halfhalfEmbodiedContributionTypes(),
     description: 'With your environment as the shared canvas, pose your body to be the mirror image of a friend',
     notificationText: 'Your situation made you available to participate in Body Mirror!',
-    callbacks: [{
-      trigger: 'cb.number()',
-      function: sendNotificationTwoHalvesCompleted.toString()
-    }]
+    callbacks: createCallbacksForEmbodiedMimicry(halfhalfEmbodiedContributionTypes())
   },
   scavengerHunt: {
     _id: Random.id(),

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -1134,8 +1134,8 @@ export const CONSTANTS = {
   'LOCATIONS': LOCATIONS,
   'USERS': USERS,
   // Comment out if you would like to only test specific experiences
-  'EXPERIENCES': (({ halfhalfEmbodiedMimicry }) => ({ halfhalfEmbodiedMimicry }))(EXPERIENCES),
-  // 'EXPERIENCES': EXPERIENCES,
+  // 'EXPERIENCES': (({ halfhalfEmbodiedMimicry }) => ({ halfhalfEmbodiedMimicry }))(EXPERIENCES),
+  'EXPERIENCES': EXPERIENCES,
   'DETECTORS': DETECTORS
 };
 

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -797,7 +797,7 @@ let EXPERIENCES = {
       toPass: {
         instruction: 'Take a photo of like Half Half Travel!'
       },
-      numberNeeded: 2,
+      numberNeeded: 10,
       notificationDelay: 1,
     }],
     description: 'Create adventures that meet halfway! Ready to live in a parallel with someone else?',

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -852,8 +852,7 @@ const halfhalfEmbodiedContributionTypes = function() {
     },
     toPass: {
       instruction: 'Do you notice the details of religious buildings? Do so now, by outstretching your hand and pointing out of the elements that stick out to you most.',
-      // TODO(rlouie): take a photo for embodied mimicry of a building
-      // exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-visual-mimicry-religious.jpg'
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-religious-building.jpg'
     },
     numberNeeded: 50,
     notificationDelay: 30
@@ -865,6 +864,7 @@ const halfhalfEmbodiedContributionTypes = function() {
     },
     toPass: {
       instruction: 'What does the sunset look like where you are? Find a good view of the sunset. Then, take a photo, with your hands outstretched towards the sun.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-sunset-heart.jpg'
     },
     numberNeeded: 50,
     notificationDelay: 1,
@@ -898,7 +898,7 @@ const halfhalfEmbodiedContributionTypes = function() {
       number: '1'
     },
     toPass: {
-      instruction: 'You must be filling up at the station! Take a photo of your hand holding the filling pump'
+      instruction: 'You must be filling up at the station! Take a photo of your hand holding the filling pump.'
     },
     numberNeeded: 50,
     notificationDelay: 60 * 2
@@ -914,6 +914,42 @@ const halfhalfEmbodiedContributionTypes = function() {
     },
     numberNeeded: 50,
     notificationDelay: 60 * 10
+  }, {
+    needName: 'Hold a flower',
+    situation: {
+      detector: DETECTORS.forest._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Find a flower in the park or garden. Take a photo, with your hand shaped as a half-circle.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-hand-circles-flower.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 15
+  }, {
+    needName: 'Feet towards the trees',
+    situation: {
+      detector: DETECTORS.forest._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Find a patch of grass to lay your back on. Then, raise your feet. Take a photo of your foot stretching high into the sky',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-feet-towards-trees.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 15
+  }, {
+    needName: 'Leaf Mask',
+    situation: {
+      detector: DETECTORS.forest._id,
+      number: '1'
+    },
+    toPass: {
+      instruction: 'Find a leaf in the park. Take a photo of the leaf covering your face, like it was a mask.',
+      exampleImage: 'https://s3.us-east-2.amazonaws.com/ce-platform/oce-example-images/half-half-embodied-mimicry-leaf-face.jpg'
+    },
+    numberNeeded: 50,
+    notificationDelay: 15
   }];
 };
 

--- a/imports/api/UserMonitor/detectors/detectors.tests.js
+++ b/imports/api/UserMonitor/detectors/detectors.tests.js
@@ -8,7 +8,7 @@ import { Detectors } from './detectors';
 import { CONSTANTS } from "../../Testing/testingconstants";
 
 
-describe('Detector Tests', function () {
+describe('Small Detector Tests', function () {
   let detectorId = CONSTANTS.DETECTORS.produce._id;
 
   beforeEach(function () {
@@ -61,4 +61,32 @@ describe('Detector Tests', function () {
   //   });
   //
   // });
+});
+
+describe('Detectors in testingcontants.js are valid', function() {
+
+  before(function () {
+    resetDatabase();
+    _.forEach(Object.keys(CONSTANTS.DETECTORS), (key) => {
+      Detectors.insert(CONSTANTS.DETECTORS[key]);
+    });
+  });
+
+  it('should compile when applying the detector', function() {
+
+    // this affordance can be arbitrary
+    let affordances = {'grocery': true};
+
+    let allDetectors = Detectors.find().fetch();
+
+    _.forEach(allDetectors, (detector) => {
+      try {
+        matchAffordancesWithDetector(affordances, detector._id);
+      } catch(err) {
+        console.error(`Detector failed to compile with id (${detector._id}) and description (${detector.description})`)
+        throw(err);
+      }
+    });
+  });
+
 });

--- a/imports/startup/client/router.js
+++ b/imports/startup/client/router.js
@@ -16,6 +16,9 @@ import '../../ui/pages/api_custom.js';
 import '../../ui/pages/api_custom_results.html';
 import '../../ui/pages/api_custom_results.js';
 import '../../ui/pages/affordances.js';
+import '../../ui/pages/participate_backdoor.html';
+import '../../ui/pages/participate_backdoor.js';
+
 
 import { Experiences, Incidents } from "../../api/OCEManager/OCEs/experiences";
 import { Locations } from "../../api/UserMonitor/locations/locations";
@@ -105,6 +108,19 @@ Router.route('/', {
   name: 'home',
 });
 
+Router.route('participate.backdoor', {
+  path: '/participate/backdoor',
+  template: 'participateBackdoor',
+  before: function() {
+    this.subscribe('submissions.all').wait();
+    this.next();
+  },
+  data: function () {
+    return {
+      submissions: Submissions.find({}).fetch()
+    }
+  }
+});
 
 Router.route('admin.debug', {
   path: '/admin/debug',

--- a/imports/ui/pages/api_custom.html
+++ b/imports/ui/pages/api_custom.html
@@ -37,19 +37,6 @@
         padding-bottom: 4%;
       }
 
-
-      /*.pos1 {grid-area: pos1}*/
-      /*.pos2 {grid-area: pos2}*/
-      /*.pos3 {grid-area: pos3}*/
-      /*.pos4 {grid-area: pos4}*/
-      /*.pos5 {grid-area: pos5}*/
-      /*.camera-controls {*/
-        /*display: grid;*/
-        /*!* 5vw x 4 gaps = 20vw *!*/
-        /*grid-gap: 5vw;*/
-        /*grid-template-columns: repeat(5, 13vw);*/
-        /*grid-template-areas: "pos1 pos2 pos3 pos4 pos5";*/
-      /*}*/
     </style>
   </head>
 
@@ -67,6 +54,12 @@
       {{/if}}
     {{/let}}
   </div>
+  {{#if this.toPass.exampleImage}}
+    <div>
+      <u>Example to try</u>
+      <img style="width: 100%; margin-bottom: 10px" src="{{this.toPass.exampleImage}}"/>
+    </div>
+  {{/if}}
   <form id="participate">
     <div id="cameraOverlay" class="camera-overlay">
       {{> loadingOverlay}}

--- a/imports/ui/pages/api_custom.html
+++ b/imports/ui/pages/api_custom.html
@@ -83,6 +83,8 @@
     </div>
 
     <div class="camera-controls">
+      <!-- LEAVE testImage button commented out!!! -->
+      <!--<button type="button" id="testImage" class="left-control">Test</button>-->
       <button type="button" id="startCamera" class="btn-borderless center-control">
         <span class="glyphicon glyphicon-camera glyphicon-large"></span>
       </button>

--- a/imports/ui/pages/api_custom.html
+++ b/imports/ui/pages/api_custom.html
@@ -42,7 +42,7 @@
 
   <div class="instruction">
     {{this.toPass.instruction}}
-    {{#let needImages=(imagesByNeed this.images this.needName) }}
+    {{#let needImages=(mostRecentImageDyadForNeed this.images this.needName) }}
       {{#if (lengthEqual needImages 1) }}
         {{#let image=(firstElement needImages) }}
           {{#let user=(getUserById users image.uid) }}
@@ -63,7 +63,7 @@
   <form id="participate">
     <div id="cameraOverlay" class="camera-overlay">
       {{> loadingOverlay}}
-      {{#let needImages=(imagesByNeed this.images this.needName) }}
+      {{#let needImages=(mostRecentImageDyadForNeed this.images this.needName) }}
         {{#if (lengthEqual needImages 1) }}
           <div id="leftHalf" class="lefthalf halfsquare">
             <div class="content">

--- a/imports/ui/pages/api_custom.js
+++ b/imports/ui/pages/api_custom.js
@@ -145,7 +145,7 @@ Template.halfhalfParticipate.onDestroyed(() => {
 });
 
 Template.halfhalfParticipate.events({
- 'click #startCamera'(event, template){
+  'click #startCamera'(event, template){
     if (typeof CameraPreview !== 'undefined') {
       startCameraAtPreviewRect();
       Session.set('CameraPreviewOn', true);
@@ -180,7 +180,7 @@ Template.halfhalfParticipate.events({
     } else {
       console.error("Could not access the CameraPreview")
     }
- },
+  },
   'click #retakePhoto'(event, template){
     if (typeof CameraPreview !== 'undefined') {
       CameraPreview.show()
@@ -198,7 +198,15 @@ Template.halfhalfParticipate.events({
     } else {
       console.error("Could not access the CameraPreview")
     }
-  }
+  },
+  // LEAVE click #testImage event commented out! For non-mobile testing only
+  // 'click #testImage'(event, template) {
+  //   // let sampleImgSrc = "data:image/png:base64..."
+  //   let imagePreview = template.$(".fileinput-preview");
+  //   imagePreview.attr('src', sampleImgSrc);
+  //   imagePreview.show();
+  //   template.imageSubmitReady.set(true);
+  // }
 });
 
 /** Based on whether the preview window is on the left or right, this function returns the rectangle that
@@ -403,7 +411,8 @@ Template.api_custom.events({
 
 
     const experience = this.experience;
-    const location = this.location;
+    // give null values for use when testing submitted photos on the web, without location data
+    const location = this.location ? this.location : {lat: null, lng: null};
     const iid = Router.current().params.iid;
     const needName = Router.current().params.needName;
     const uid = Meteor.userId();

--- a/imports/ui/pages/api_custom.js
+++ b/imports/ui/pages/api_custom.js
@@ -258,7 +258,7 @@ const getPreviewRect = function() {
 
 const startCameraAtPreviewRect = function(
   {
-    camera = "front",
+    camera = "back",
     tapPhoto = true,
     previewDrag = false,
     toBack = true

--- a/imports/ui/pages/api_custom.js
+++ b/imports/ui/pages/api_custom.js
@@ -81,6 +81,23 @@ Template.bumped.helpers({
   }
 });
 
+/**
+ * Returns an array with arrays of the given size.
+ *
+ * @param myArray {Array} Array to split
+ * @param chunkSize {Integer} Size of every group
+ * @see https://ourcodeworld.com/articles/read/278/how-to-split-an-array-into-chunks-of-the-same-size-easily-in-javascript
+ */
+export const chunkArray = (myArray, chunk_size) => {
+  let results = [];
+
+  while (myArray.length) {
+    results.push(myArray.splice(0, chunk_size));
+  }
+
+  return results;
+};
+
 Template.halfhalfParticipate.helpers({
   getUserById(users, uid) {
     let user = users.find(function(x) {
@@ -88,11 +105,22 @@ Template.halfhalfParticipate.helpers({
     });
     return user;
   },
-  // images already filtered by activeIncident. Now get it for current need
-  imagesByNeed(images, needName) {
-    return images.filter(function(x) {
+  /** mostRecentImageDyadForNeed
+   *
+   * @param images [Image document object] assumes documents already filtered by activeIncident
+   * @param needName [String] need name
+   * @return [ImageDocument, ImageDocument] or [ImageDocument]
+   */
+  mostRecentImageDyadForNeed(images, needName) {
+    // assure they are sorted in ascending (first uploadedAt first)
+    images = images.sort(function(x, y) {
+      return x.uploadedAt - y.uploadedAt;
+    });
+    let needImages = images.filter(function(x) {
       return x.needName === needName;
-    })
+    });
+    let imagesGroupedByDyad = chunkArray(needImages, 2);
+    return imagesGroupedByDyad[imagesGroupedByDyad.length - 1];
   },
   lengthEqual(array, number) {
     return array.length === number;

--- a/imports/ui/pages/api_custom_results.html
+++ b/imports/ui/pages/api_custom_results.html
@@ -89,9 +89,9 @@
       .centered {
         text-align: center;
       }
-      .need-group-container {
+      .image-group-container {
         /* give some space for the following text*/
-        margin-bottom: 40px;
+        margin-bottom: 50px;
       }
     </style>
   </head>
@@ -101,33 +101,35 @@
     {{#each needGroup in resultsGroupedByNeedAndDyad}}
       <div class="need-group-container">
         <div>{{needGroup.needName}}</div>
-        <div class="camera-overlay">
-          {{#each imageGroup in needGroup.imagesGroupedByDyad}}
-            {{#if (lengthEqual imageGroup 2) }}
-              {{#each image in imageGroup}}
-                <div class="half{{@index}} centered halfsquare">
-                  {{#let user=(getUserById users image.uid)}}
-                    <u>{{user.username}}</u>
-                  {{/let}}
-                  <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
-                </div>
-              {{/each}}
-            {{else}}
-              {{#let image=(elementAtIndex imageGroup 0) }}
-                <div class="half0 centered halfsquare">
-                  {{#let user=(getUserById users image.uid)}}
-                    <u>{{user.username}}</u>
-                  {{/let}}
-                  <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
-                </div>
-                <div class="half1 halfsquare">
-                  <br/>
-                  <div class="content" style="background-color: rgba(125,125,125,0.5);">Waiting for another person to fill in the right half!</div>
-                </div>
-              {{/let}}
-            {{/if}}
-          {{/each}}
-        </div>
+        {{#each imageGroup in needGroup.imagesGroupedByDyad}}
+          <div class="image-group-container">
+            <div class="camera-overlay">
+              {{#if (lengthEqual imageGroup 2) }}
+                {{#each image in imageGroup}}
+                  <div class="half{{@index}} centered halfsquare">
+                    {{#let user=(getUserById users image.uid)}}
+                      <u>{{user.username}}</u>
+                    {{/let}}
+                    <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
+                  </div>
+                {{/each}}
+              {{else}}
+                {{#let image=(elementAtIndex imageGroup 0) }}
+                  <div class="half0 centered halfsquare">
+                    {{#let user=(getUserById users image.uid)}}
+                      <u>{{user.username}}</u>
+                    {{/let}}
+                    <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
+                  </div>
+                  <div class="half1 halfsquare">
+                    <br/>
+                    <div class="content" style="background-color: rgba(125,125,125,0.5);">Waiting for another person to fill in the right half!</div>
+                  </div>
+                {{/let}}
+              {{/if}}
+            </div>
+          </div>
+        {{/each}}
       </div>
     {{/each}}
   </div>

--- a/imports/ui/pages/api_custom_results.html
+++ b/imports/ui/pages/api_custom_results.html
@@ -89,31 +89,46 @@
       .centered {
         text-align: center;
       }
+      .need-group-container {
+        /* give some space for the following text*/
+        margin-bottom: 40px;
+      }
     </style>
   </head>
 
-  {{#each needGroup in resultsGroupedByNeed}}
-    <div>{{needGroup.needName}}</div>
-    <div class="camera-overlay">
-    {{#if (lengthEqual needGroup.images 2) }}
-      {{#each image in needGroup.images}}
-        <div class="half{{@index}} centered">
-          {{#let user=(getUserById users image.uid)}}
-            <u>{{user.username}}</u>
-          {{/let}}
-          {{> Template.dynamic template="displayFullImage" data=image}}
+  <div id="results">
+    <h4>{{this.experience.name}}</h4>
+    {{#each needGroup in resultsGroupedByNeed}}
+      <div class="need-group-container">
+        <div>{{needGroup.needName}}</div>
+        <div class="camera-overlay">
+          {{#if (lengthEqual needGroup.images 2) }}
+            {{#each image in needGroup.images}}
+              <div class="half{{@index}} centered halfsquare">
+                {{#let user=(getUserById users image.uid)}}
+                  <u>{{user.username}}</u>
+                {{/let}}
+                <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
+              </div>
+            {{/each}}
+          {{else}}
+            {{#let image=(elementAtIndex needGroup.images 0) }}
+              <div class="half0 centered halfsquare">
+                {{#let user=(getUserById users image.uid)}}
+                  <u>{{user.username}}</u>
+                {{/let}}
+                <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
+              </div>
+              <div class="half1 halfsquare">
+                <br/>
+                <div class="content" style="background-color: rgba(125,125,125,0.5);">Waiting for another person to fill in the right half!</div>
+              </div>
+            {{/let}}
+          {{/if}}
         </div>
-      {{/each}}
-    {{else}}
-      <div class="half0">
-        {{> Template.dynamic template="displayFullImage" data=(elementAtIndex needGroup.images 0) }}
       </div>
-      <div class="half1" style="background-color: rgba(125,125,125,0.5);">
-        Waiting for your second half!
-      </div>
-    {{/if}}
-    </div>
-  {{/each}}
+    {{/each}}
+  </div>
 </template>
 
 <template name="cheersResults">

--- a/imports/ui/pages/api_custom_results.html
+++ b/imports/ui/pages/api_custom_results.html
@@ -98,33 +98,35 @@
 
   <div id="results">
     <h4>{{this.experience.name}}</h4>
-    {{#each needGroup in resultsGroupedByNeed}}
+    {{#each needGroup in resultsGroupedByNeedAndDyad}}
       <div class="need-group-container">
         <div>{{needGroup.needName}}</div>
         <div class="camera-overlay">
-          {{#if (lengthEqual needGroup.images 2) }}
-            {{#each image in needGroup.images}}
-              <div class="half{{@index}} centered halfsquare">
-                {{#let user=(getUserById users image.uid)}}
-                  <u>{{user.username}}</u>
-                {{/let}}
-                <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
-              </div>
-            {{/each}}
-          {{else}}
-            {{#let image=(elementAtIndex needGroup.images 0) }}
-              <div class="half0 centered halfsquare">
-                {{#let user=(getUserById users image.uid)}}
-                  <u>{{user.username}}</u>
-                {{/let}}
-                <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
-              </div>
-              <div class="half1 halfsquare">
-                <br/>
-                <div class="content" style="background-color: rgba(125,125,125,0.5);">Waiting for another person to fill in the right half!</div>
-              </div>
-            {{/let}}
-          {{/if}}
+          {{#each imageGroup in needGroup.imagesGroupedByDyad}}
+            {{#if (lengthEqual imageGroup 2) }}
+              {{#each image in imageGroup}}
+                <div class="half{{@index}} centered halfsquare">
+                  {{#let user=(getUserById users image.uid)}}
+                    <u>{{user.username}}</u>
+                  {{/let}}
+                  <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
+                </div>
+              {{/each}}
+            {{else}}
+              {{#let image=(elementAtIndex imageGroup 0) }}
+                <div class="half0 centered halfsquare">
+                  {{#let user=(getUserById users image.uid)}}
+                    <u>{{user.username}}</u>
+                  {{/let}}
+                  <div class="content">{{> Template.dynamic template="displayFullImage" data=image}}</div>
+                </div>
+                <div class="half1 halfsquare">
+                  <br/>
+                  <div class="content" style="background-color: rgba(125,125,125,0.5);">Waiting for another person to fill in the right half!</div>
+                </div>
+              {{/let}}
+            {{/if}}
+          {{/each}}
         </div>
       </div>
     {{/each}}
@@ -293,7 +295,6 @@
               <div class="illustration row">
                   {{> Template.dynamic template="displayImage" data=(getImageById this submission.content.illustration)}}
               </div>
-
               {{else}}
               <div class="illustration row" style="text-align: center; vertical-align: middle; line-height: 350px;">
                   <i>We're looking for another user to illustrate your sentence...</i>

--- a/imports/ui/pages/api_custom_results.js
+++ b/imports/ui/pages/api_custom_results.js
@@ -123,7 +123,7 @@ Template.bumpedResults.events({
  * @param chunkSize {Integer} Size of every group
  * @see https://ourcodeworld.com/articles/read/278/how-to-split-an-array-into-chunks-of-the-same-size-easily-in-javascript
  */
-function chunkArray(myArray, chunk_size){
+export const chunkArray = (myArray, chunk_size) => {
   let results = [];
 
   while (myArray.length) {
@@ -131,7 +131,7 @@ function chunkArray(myArray, chunk_size){
   }
 
   return results;
-}
+};
 
 Template.halfhalfResults.helpers({
   lengthEqual(arr, number) {

--- a/imports/ui/pages/api_custom_results.js
+++ b/imports/ui/pages/api_custom_results.js
@@ -116,6 +116,23 @@ Template.bumpedResults.events({
 
 });
 
+/**
+ * Returns an array with arrays of the given size.
+ *
+ * @param myArray {Array} Array to split
+ * @param chunkSize {Integer} Size of every group
+ * @see https://ourcodeworld.com/articles/read/278/how-to-split-an-array-into-chunks-of-the-same-size-easily-in-javascript
+ */
+function chunkArray(myArray, chunk_size){
+  let results = [];
+
+  while (myArray.length) {
+    results.push(myArray.splice(0, chunk_size));
+  }
+
+  return results;
+}
+
 Template.halfhalfResults.helpers({
   lengthEqual(arr, number) {
     return arr.length === number;
@@ -129,7 +146,10 @@ Template.halfhalfResults.helpers({
   elementAtIndex(arr, index){
     return arr[index];
   },
-  resultsGroupedByNeed() {
+  /** So we can show the contributions of a dyad, for each need
+   * @returns {needName: String, imagesGroupedByDyad: [(a,b) (c, d) (e)]}
+   */
+  resultsGroupedByNeedAndDyad() {
 
     let mySubs = this.submissions.filter(function(x){
       return x.uid === Meteor.userId();
@@ -144,10 +164,12 @@ Template.halfhalfResults.helpers({
       let needImages = this.images.filter((img) => {
         return img.needName == needName;
       });
-      return {needName: needName, images: needImages};
+
+      return {needName: needName, imagesGroupedByDyad: chunkArray(needImages, 2)};
     });
   }
 });
+
 
 Template.scavengerHunt.helpers({
   categories() {

--- a/imports/ui/pages/participate.scss
+++ b/imports/ui/pages/participate.scss
@@ -43,6 +43,11 @@
     padding: 1vw;
   }
 
+  .camera-controls {
+    // this margin matches the height of the bottom nav bar, so it wont overlap the camera icon
+    margin-bottom: 52px;
+  }
+
   .left-control {
     position: absolute;
     margin-top: 10px;

--- a/imports/ui/pages/participate_backdoor.html
+++ b/imports/ui/pages/participate_backdoor.html
@@ -1,0 +1,7 @@
+<template name="participateBackdoor">
+  <ul>
+    {{#each link in apiCustomLinks}}
+      <li><a href="{{link}}" target="_blank">{{link}}</a></li>
+    {{/each}}
+  </ul>
+</template>

--- a/imports/ui/pages/participate_backdoor.js
+++ b/imports/ui/pages/participate_backdoor.js
@@ -4,7 +4,6 @@ import {Template} from 'meteor/templating';
 
 Template.participateBackdoor.helpers({
   apiCustomLinks() {
-    console.log(this.submissions);
     let links = this.submissions.map((sub) => {
       return `/apicustom/${sub.iid}/${sub.eid}/${sub.needName}`
     });

--- a/imports/ui/pages/participate_backdoor.js
+++ b/imports/ui/pages/participate_backdoor.js
@@ -1,0 +1,14 @@
+import './participate_backdoor.html';
+
+import {Template} from 'meteor/templating';
+
+Template.participateBackdoor.helpers({
+  apiCustomLinks() {
+    console.log(this.submissions);
+    let links = this.submissions.map((sub) => {
+      return `/apicustom/${sub.iid}/${sub.eid}/${sub.needName}`
+    });
+
+    return [... new Set(links)];
+  }
+});

--- a/imports/ui/pages/results.scss
+++ b/imports/ui/pages/results.scss
@@ -46,4 +46,24 @@
     font-size: 12px;
     color: rgba(0, 0, 0, 0.6);
   }
+
+  .halfsquare {
+    position: relative;
+    box-sizing: border-box;
+  }
+
+  .halfsquare::before {
+    content: '';
+    display: block;
+    /*since 100% containing div width is half the sidelength of a square,*/
+    /*200% of containing div width is the full sidelength of a square.*/
+    padding-top: 200%;
+  }
+
+  .halfsquare .content {
+    position: absolute;
+    top: 0; left: 0;
+    height: 100%;
+    width: 100%;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ce-platform",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Summary: 

Half Half Experience (`api_custom.html/js`, `api_custom_results.html/js`, `testingconstants.js`)
* Created new halfhalfEmbodiedMimicry experience, with > 5 needs
* For Half Half, there is a new field `toPass.exampleImage` which can link to an external image (i.e. hosted on S3) that can prompt the person to take a certain kind of photo
* Made the half half experiences so that many people can participate in groups of pairs (i.e. 50 people could participate as 25 halves). __UPDATE:__ HQ Suggested that we use the callback to create a new need for pairs.  Think about this alternative.  __Pros:__ 1) Won't make 50 flat, and will go on forever which is nice for users who keep signing on. __Neutral:__ 1) If new need created, then everyone will be eligible to keep participating. Right now, I think duplicate participation in a need is restricted.
* For the API Interface Model, now numberNeeded will be 50, but the pairs are implicit to the template logic.  So thats a little weird... Wish we could specify the fact that there are asynchronous pairs within the experience definition.
* For the Participant Interface Model, now people will see participation of all the people, for a need.  For example, everyone who did a Half Half grocery experience will be displayed in the results, and they will be able to view everyone else who participated.  We'd expect the outcome for participants to be feeling closer to people, even those who weren't in their dyad, but the fact that everyone is taking half-half photos for a need they also participated in.

Detectors (`detectors.tests.js`, `testingconstants.js`, `createNewExperiences.js`)
* Created new test that loads in all the detectors from testingconstants, and tries to run them.
* This revealed that some of the old detectors were broken based on how the rules were being written.  These were fixed.
* new method `upsertDetector` with helps with updating the detectors on production after pushing a new version in testingconstants

Participate Backdoor (`routes.js` and `participate_backdoor.html/js`)
* New route and page that will link to the participate screens for all the experiences.  This is nice helper page so I can get previews of what all the screens look like, without having to simulate matching to these experiences in order to see the screen.

Testing: 
* 14 out of 15 tests passing
* `Meteor.call('createOCE', {name: 'halfhalfEmbodiedMimicry'})` created corresponding DB items
* __TODO(rlouie): Create function that can insert or update newest detectors in testingconstants.js via a Meteor.Call__

﻿Half Half Embodied Mimicry
<img width="340" alt="screen shot 2018-07-30 at 2 26 39 pm" src="https://user-images.githubusercontent.com/5459644/43418763-9a939e88-9404-11e8-8af3-9b433c845161.png">

More Screenshots of Same Situation, Across Time Embodied Mimicry Interactions
<img width="526" alt="image" src="https://user-images.githubusercontent.com/5459644/43434237-704a309c-9440-11e8-9ea2-9daa2901d435.png">

Participate Backdoor at /participate/backdoor

<img width="718" alt="image" src="https://user-images.githubusercontent.com/5459644/43754469-98f2bdda-99d0-11e8-8cd2-d3975e8c622e.png">
