### PR TITLE
Commented call to checkIfFailed, to fix submissions bug

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,12 +83,16 @@ iron:url@1.1.0
 jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
+lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.1.20
 mdg:validated-method@1.1.0
 mdg:validation-error@0.5.1
 meteor@1.8.6
 meteor-base@1.3.0
+meteorhacks:picker@1.0.3
+meteortesting:browser-tests@1.0.0
+meteortesting:mocha@1.0.0
 meteortoys:toykit@3.0.4
 minifier-css@1.3.1
 minifier-js@2.3.5

--- a/imports/api/OCEManager/OCEs/experiences.tests.js
+++ b/imports/api/OCEManager/OCEs/experiences.tests.js
@@ -4,12 +4,13 @@ import { CONSTANTS } from "../../Testing/testingconstants";
 describe('Experience Tests', () => {
   it('insert OCEs into database', () => {
 
-    Experiences.insert(CONSTANTS.experiences.atLocation, (err) => {
-      if (err) {
-        chai.assert(false);
-      } else {
-        chai.assert(true);
-      }
+    _.forEach(Object.keys(CONSTANTS.EXPERIENCES), (OCE_NAME) => {
+      Experiences.insert(CONSTANTS.EXPERIENCES[OCE_NAME], (err) => {
+        if (err) {
+          chai.assert(false, `Failed to insert CONSTANTS.EXPERIENCED.${OCE_NAME}`);
+        }
+      });
     });
+
   })
 });

--- a/imports/api/OCEManager/progressor.js
+++ b/imports/api/OCEManager/progressor.js
@@ -6,19 +6,19 @@ import {adminUpdates} from "./progressorHelper";
 // needed because a callback uses `notify`
 import {notify} from "../OpportunisticCoordinator/server/noticationMethods";
 
-// const submissionsCursor = Submissions.find({});
-// const submissionsHandle = submissionsCursor.observe({
-//   //TODO: make it so we can check the submission when through completely first?
-//   //e.g. if a photo upload fails this will still run not matter what
-//   changed(submission, old) {
-//     serverLog.call({message: `Submissions DB Changed!`});
-//     serverLog.call({message: `${Object.keys(submission)}`});
-//     if(!(submission.uid === null)){
-//       adminUpdates(submission);
-//       runCallbacks(submission);
-//     }
-//   }
-// });
+const submissionsCursor = Submissions.find({});
+const submissionsHandle = submissionsCursor.observe({
+  //TODO: make it so we can check the submission when through completely first?
+  //e.g. if a photo upload fails this will still run not matter what
+  changed(submission, old) {
+    serverLog.call({message: `Submissions DB Changed!`});
+    serverLog.call({message: `${Object.keys(submission)}`});
+    if(!(submission.uid === null)){
+      adminUpdates(submission);
+      runCallbacks(submission);
+    }
+  }
+});
 Meteor.methods({
   updateSubmission(submission) {
     updateSubmission(submission);
@@ -26,64 +26,28 @@ Meteor.methods({
 });
 
 export const updateSubmission = function(submission) {
-  if (submission.uid !== null) {
-    // called without callback, therefore update blocks until db acknowledges write, or throws exception
-    Submissions.update(
-      {
-        eid: submission.eid,
-        iid: submission.iid,
-        needName: submission.needName,
-        uid: null
-      },
-      {
-        $set: {
-          uid: submission.uid,
-          content: submission.content,
-          timestamp: submission.timestamp,
-          lat: submission.lat,
-          lng: submission.lng
-        }
-      },
-    );
-
-    // TODO: make it so we can check the submission when through completely first?
-    // e.g. if a photo upload fails this will still run not matter what
-    const updatedSub = Submissions.find(
-      {
-        // identifiers
-        eid: submission.eid,
-        iid: submission.iid,
-        needName: submission.needName,
-        timestamp: submission.timestamp
-      });
-    adminUpdates(updatedSub);
-    runCallbacks(updatedSub);
-
-  } else {
-    serverLog.call({message: 'Submission not inserted because it did not come with a uid'});
-  }
-  // Submissions.update(
-  //   {
-  //     eid: submission.eid,
-  //     iid: submission.iid,
-  //     needName: submission.needName,
-  //     uid: null
-  //   },
-  //   {
-  //     $set: {
-  //       uid: submission.uid,
-  //       content: submission.content,
-  //       timestamp: submission.timestamp,
-  //       lat: submission.lat,
-  //       lng: submission.lng
-  //     }
-  //   },
-  //   (err) => {
-  //     if (err) {
-  //       console.log("submission not inserted", err);
-  //     }
-  //   }
-  // );
+  Submissions.update(
+    {
+      eid: submission.eid,
+      iid: submission.iid,
+      needName: submission.needName,
+      uid: null
+    },
+    {
+      $set: {
+        uid: submission.uid,
+        content: submission.content,
+        timestamp: submission.timestamp,
+        lat: submission.lat,
+        lng: submission.lng
+      }
+    },
+    (err) => {
+      if (err) {
+        console.log("submission not inserted", err);
+      }
+    }
+  );
 };
 
 //checks the triggers for the experience of the new submission and runs the appropriate callbacks 5

--- a/imports/api/OCEManager/progressor.js
+++ b/imports/api/OCEManager/progressor.js
@@ -11,7 +11,8 @@ const submissionsHandle = submissionsCursor.observe({
   //TODO: make it so we can check the submission when through completely first?
   //e.g. if a photo upload fails this will still run not matter what
   changed(submission, old) {
-    serverLog.call({message: `Submissions DB Changed! \n ${submission}`});
+    serverLog.call({message: `Submissions DB Changed!`});
+    serverLog.call({message: `${Object.keys(submission)}`});
     if(!(submission.uid === null)){
       adminUpdates(submission);
       runCallbacks(submission);

--- a/imports/api/OCEManager/progressor.tests.js
+++ b/imports/api/OCEManager/progressor.tests.js
@@ -1,0 +1,105 @@
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import {numUnfinishedNeeds, runCallbacks, updateSubmission} from "./progressor";
+import {createIncidentFromExperience, startRunningIncident} from "./OCEs/methods";
+import {CONSTANTS} from "../Testing/testingconstants";
+import {Experiences, Incidents} from "./OCEs/experiences";
+import {Submissions} from "./currentNeeds";
+import {adminUpdates} from "./progressorHelper";
+
+describe('Progressor Tests', function() {
+
+  const testExperience = 'halfhalfDay';
+  let numUnfinishedBefore;
+  let numSubsBefore;
+  let needName;
+  let experience;
+  let incident;
+  let submissionObject;
+
+  before(function() {
+    resetDatabase();
+
+    // createOCE
+    // NOTE: DETECTORS are unnecessary, since we will trigger the assignment to needs manually
+    let testExp = CONSTANTS.EXPERIENCES[testExperience];
+    Experiences.insert(testExp);
+    let testIncident = createIncidentFromExperience(testExp);
+    // Submissions, Availability, and Assignments are inserted here
+    startRunningIncident(testIncident);
+
+    // update Submissions
+    needName = CONSTANTS.EXPERIENCES[testExperience].contributionTypes[0].needName;
+    experience = Experiences.findOne(testExp);
+    incident = Incidents.findOne(testIncident);
+    numUnfinishedBefore = numUnfinishedNeeds(incident._id, needName);
+    numSubsBefore = Submissions.find({iid: incident._id, needName: needName}).count();
+    submissionObject = {
+      uid: Random.id(),
+      eid: experience._id,
+      iid: incident._id,
+      needName: needName,
+      content: {}, // not important in this test
+      timestamp: Date.now(),
+      lat: null, // not important in this test
+      lng: null, // not important in this test
+    };
+    // TODO(rlouie): since it seems impossible to wait for Submissions DB to change, and the observe callbacks to occur,
+    // TODO(cont'd): these tests pass, but submissions might be altered at a later time in an undesirable way
+    updateSubmission(submissionObject);
+  });
+
+  it('should update submissions for single user-need participation', function() {
+    const justSubmitted = Submissions.findOne({
+      eid: submissionObject.eid,
+      iid: submissionObject.iid,
+      needName: submissionObject.needName,
+      uid: submissionObject.uid
+    });
+    const numUnfinishedAfter = numUnfinishedNeeds(incident._id, submissionObject.needName);
+    const numSubsAfter = Submissions.find({iid: incident._id, needName: submissionObject.needName}).count();
+
+    chai.assert.typeOf(justSubmitted, 'Object', 'Should have found the submission that was just updated');
+    chai.assert.equal(numSubsBefore, numSubsAfter, `Number of submissions should not change, only contents of them`);
+    chai.assert.equal(numUnfinishedBefore - 1, numUnfinishedAfter,
+      `Before single user submission: ${numUnfinishedBefore} unfinished needs; After: ${numUnfinishedAfter}`
+    );
+
+    // @see https://wietse.loves.engineering/testing-promises-with-mocha-90df8b7d2e35
+    // @see https://stackoverflow.com/questions/11235815/is-there-a-way-to-get-chai-working-with-asynchronous-mocha-tests
+    // if you want this Promise/Timeout code to work
+    // add `async` before callback definition i.e. `async function() {}`
+    // const subUpdatedPromise = new Promise((resolve) => {
+    //   setTimeout(() => {
+    //     const justSubmitted = Submissions.findOne({
+    //       eid: submissionObject.eid,
+    //       iid: submissionObject.iid,
+    //       needName: submissionObject.needName,
+    //       uid: submissionObject.uid
+    //     });
+    //     const numUnfinishedAfter = numUnfinishedNeeds(incident._id, needName);
+    //     const numSubsAfter = Submissions.find({iid: incident._id, needName: needName}).count();
+    //
+    //     const result = {
+    //       justSubmitted: justSubmitted,
+    //       numUnfinishedAfter: numUnfinishedAfter,
+    //       numSubsAfter: numSubsAfter
+    //     };
+    //     resolve(result);
+    //   }, 100);
+    // });
+    //
+    // try {
+    //   const result = await subUpdatedPromise;
+    //   chai.assert.typeOf(result.justSubmitted, 'Object', 'Should have found the submission that was just updated');
+    //   chai.assert.equal(numSubsBefore, result.numSubsAfter, `Number of submissions should not change, only contents of them`);
+    //   chai.assert.equal(numUnfinishedBefore - 1, result.numUnfinishedAfter,
+    //     `Before single user submission: ${numUnfinishedBefore} unfinished needs; After: ${result.numUnfinishedAfter}`
+    //   );
+    //   done();
+    // } catch(err) {
+    //   done(err);
+    // }
+
+  });
+
+});

--- a/imports/api/OCEManager/progressor.tests.js
+++ b/imports/api/OCEManager/progressor.tests.js
@@ -5,9 +5,7 @@ import {CONSTANTS} from "../Testing/testingconstants";
 import {Experiences, Incidents} from "./OCEs/experiences";
 import {Submissions} from "./currentNeeds";
 import {adminUpdatesForAddingUsersToIncident, updateAvailability} from "../OpportunisticCoordinator/identifier";
-import { Accounts } from 'meteor/accounts-base';
 import {findUserByUsername} from "../UserMonitor/users/methods";
-import {serverLog} from "../logs";
 
 describe('Progressor Tests', function() {
   this.timeout(30*1000);

--- a/imports/api/OpportunisticCoordinator/coordinator.tests.js
+++ b/imports/api/OpportunisticCoordinator/coordinator.tests.js
@@ -39,29 +39,21 @@ describe('Availability Tests', () => {
 
     _.forEach(firstEntry.needUserMaps, (needUserMap) => {
       if (needUserMap.needName === 'need1') {
-        if (needUserMap.uids.indexOf('1') === -1) {
-          chai.assert(false, 'user not added to need1');
-        }
+        chai.assert(needUserMap.uids.includes('1'), 'user not added to need1');
       }
 
       if (needUserMap.needName === 'need2') {
-        if (needUserMap.uids.indexOf('1') !== -1) {
-          chai.assert(false, 'user not removed from need2');
-        }
+        chai.assert.isFalse(needUserMap.uids.includes('1'), 'user not removed from need2');
       }
     });
 
     _.forEach(secondEntry.needUserMaps, (needUserMap) => {
       if (needUserMap.needName === 'need3') {
-        if (needUserMap.uids.indexOf('1') === -1) {
-          chai.assert(false, 'user not added to need 3');
-        }
+        chai.assert(needUserMap.uids.includes('1'), 'user not added to need3');
       }
 
       if (needUserMap.needName === 'need4') {
-        if (needUserMap.uids.indexOf('1') === -1) {
-          chai.assert(false, 'user not added to need 4');
-        }
+        chai.assert(needUserMap.uids.includes('1'), 'user not added to need4');
       }
     });
   })

--- a/imports/api/OpportunisticCoordinator/identifier.js
+++ b/imports/api/OpportunisticCoordinator/identifier.js
@@ -254,12 +254,14 @@ const _removeUsersFromAssignmentDb = (uids, iid, needName) => {
     );
   });
 
+  /*
   const needUserMap = getNeedUserMapForNeed(iid, needName);
 
   if (needUserMap.uids.length === 0) {
     // FIXME(rlouie): Fix and then uncomment so that needs that fail (during a synchronous OCE) are handled properly
-    // checkIfNeedFailed(iid, needName);
+    checkIfNeedFailed(iid, needName);
   }
+  */
 };
 
 export const getNeedUserMapForNeed = (iid, needName) => {
@@ -268,11 +270,15 @@ export const getNeedUserMapForNeed = (iid, needName) => {
     "needUserMaps.needName": needName
   });
 
-  let needUserMap = assignment.needUserMaps.find(x => {
-    return x.needName === needName;
-  });
+  if (assignment) {
+    serverLog.call({message: `assignment obj: ${Object.keys(assignment)}`});
+    serverLog.call({message: `needUserMaps: ${Object.keys(assignment.needUserMaps)}`});
+    let needUserMap = assignment.needUserMaps.find(x => {
+      return x.needName === needName;
+    });
 
-  return needUserMap;
+    return needUserMap;
+  }
 };
 // const locationCursor = Locations.find();
 //

--- a/imports/api/Testing/endToEndSimple.test.js
+++ b/imports/api/Testing/endToEndSimple.test.js
@@ -2,15 +2,15 @@ import { resetDatabase } from 'meteor/xolvio:cleaner';
 import { Accounts } from 'meteor/accounts-base';
 import { Experiences } from '../OCEManager/OCEs/experiences';
 import { Users } from '../UserMonitor/users/users';
-import { Incidents} from "../OCEManager/OCEs/experiences";
+import { Incidents } from "../OCEManager/OCEs/experiences";
 import { CONSTANTS } from './testingconstants';
 import { onLocationUpdate } from '../UserMonitor/locations/methods';
 import { createIncidentFromExperience, startRunningIncident } from '../OCEManager/OCEs/methods';
-import { findUserByUsername } from '../UserMonitor/users/methods';
-import { Assignments } from '../OpportunisticCoordinator/databaseHelpers';
+import { findUserByUsername } from "../UserMonitor/users/methods";
+import { Assignments} from "../OpportunisticCoordinator/databaseHelpers";
 import { Random } from 'meteor/random'
 import { Detectors } from "../UserMonitor/detectors/detectors";
-// import {updateSubmission} from "../OCEManager/client/methods";
+import { updateSubmission} from "../OCEManager/progressor";
 
 import "../OCEManager/progressorHelper";
 
@@ -20,7 +20,10 @@ let second = false;
 describe('Simple End To End', function () {
   this.timeout(30000);
 
-  let NEEDNAME = 'atProduce';
+  let OCE_NAME = 'scavengerHunt';
+  let NEEDNAME = 'greenProduce';
+  let USERNAME = 'garrett';
+
   beforeEach((done) => {
 
     if (second) {
@@ -29,68 +32,63 @@ describe('Simple End To End', function () {
     } else {
       second = true;
       resetDatabase();
-      Accounts.createUser(CONSTANTS.users.a);
-      Accounts.createUser(CONSTANTS.users.b);
-      Accounts.createUser(CONSTANTS.users.c);
+      Accounts.createUser(CONSTANTS.USERS[USERNAME]);
 
       Detectors.insert(CONSTANTS.DETECTORS.produce);
-      Experiences.insert(CONSTANTS.experiences.atLocation, (err) => {
-        if (err) {
-          console.log("ERROR INSERTING EXPERIENCE", err)
-        }
-      });
 
-      let incident = createIncidentFromExperience(CONSTANTS.experiences.atLocation);
-      startRunningIncident(incident);
+      // Start OCE
+      let testExp = CONSTANTS.EXPERIENCES[OCE_NAME];
+      Experiences.insert(testExp);
+      let testIncident = createIncidentFromExperience(testExp);
+      startRunningIncident(testIncident);
 
-      let uid = findUserByUsername('a@gmail.com')._id;
-      onLocationUpdate(uid, CONSTANTS.locations.park.lat, CONSTANTS.locations.park.lng, function () {
+      let uid = findUserByUsername(USERNAME)._id;
+      onLocationUpdate(uid, CONSTANTS.LOCATIONS.grocery.lat, CONSTANTS.LOCATIONS.grocery.lng, function () {
         done();
       });
     }
   });
 
   it('user gets added to experience', () => {
-    let incident = Incidents.findOne({ eid: CONSTANTS.experiences.atLocation._id });
+    let incident = Incidents.findOne({ eid: CONSTANTS.EXPERIENCES[OCE_NAME]._id });
     let iid = incident._id;
-    let user = findUserByUsername('a@gmail.com');
+    let user = findUserByUsername(USERNAME);
 
     //user has incident as an active incident
-    let addedToUser = (user.profile.activeIncidents.indexOf(iid) !== -1);
-    chai.assert(addedToUser, 'active incident not added to user profile');
+    chai.assert(user.profile.activeIncidents.includes(iid), 'active incident not added to user profile');
 
     //assignments has user assigned
     let assignmentEntry = Assignments.findOne({ _id: iid });
 
     let needUserMap = assignmentEntry.needUserMaps.find((x) => {
-      return x.needName === NEEDNAME;
+      return x.needName ===  NEEDNAME;
     });
 
     chai.assert.typeOf(needUserMap.uids, 'array', 'no needUserMap in Assignment DB');
-    chai.assert(needUserMap.uids.indexOf(user._id) !== -1, 'uid not in needUserMap in Assignment DB');
+    chai.assert(needUserMap.uids.includes(user._id), 'uid not in needUserMap in Assignment DB');
   });
 
   it('user participates in experience', (done) => {
-    let incident = Incidents.findOne({ eid: CONSTANTS.experiences.atLocation._id });
+    let incident = Incidents.findOne({ eid: CONSTANTS.EXPERIENCES[OCE_NAME]._id });
     let iid = incident._id;
-    let user = findUserByUsername('a@gmail.com');
+    let user = findUserByUsername(USERNAME);
 
     let submission = {
       uid: user._id,
-      eid: CONSTANTS.experiences.atLocation._id,
+      eid: CONSTANTS.EXPERIENCES[OCE_NAME]._id,
       iid: iid,
       needName: NEEDNAME,
       content: {},
       timestamp: Date.now(),
-      lat: 43,
-      lng: -87,
+      lat: CONSTANTS.LOCATIONS.grocery.lat,
+      lng: CONSTANTS.LOCATIONS.grocery.lng,
     };
 
     updateSubmission(submission);
 
     Meteor.setTimeout(function () {
-      chai.assert((user.profile.activeIncidents.indexOf(iid) === -1), 'active incident not removed from user profile');
-      chai.assert((user.profile.pastIncidents.indexOf(iid) !== -1), 'past incident not added to user profile');
+      chai.assert.isFalse(user.profile.activeIncidents.includes(iid), 'active incident not removed from user profile');
+      chai.assert(user.profile.pastIncidents.includes(iid), 'past incident not added to user profile');
       done()
     }, 20 * 1000);
 

--- a/imports/api/Testing/endToEndSimple.test.js
+++ b/imports/api/Testing/endToEndSimple.test.js
@@ -66,7 +66,7 @@ describe('Simple End To End', function () {
     });
     const notificationDelay = contributionForNeed.notificationDelay;
 
-    // Wait to check if user.profile and assignments has changed, notificationDelay seconds after first matching
+    // Wait to check if user.profile and assignments has changed, > notificationDelay seconds after first matching
     Meteor.setTimeout(function() {
       try {
         let incident = Incidents.findOne({ eid: CONSTANTS.EXPERIENCES[OCE_NAME]._id });
@@ -89,7 +89,7 @@ describe('Simple End To End', function () {
 
         done();
       } catch (err) { done(err); }
-    }, notificationDelay * 1000);
+    }, (notificationDelay + 5) * 1000);
   });
 
   it('user participates in experience', (done) => {

--- a/imports/api/Testing/endToEndSimple.test.js
+++ b/imports/api/Testing/endToEndSimple.test.js
@@ -1,5 +1,4 @@
 import { resetDatabase } from 'meteor/xolvio:cleaner';
-import { Accounts } from 'meteor/accounts-base';
 import { Experiences } from '../OCEManager/OCEs/experiences';
 import { Users } from '../UserMonitor/users/users';
 import { Incidents } from "../OCEManager/OCEs/experiences";

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "scripts": {
     "build": "meteor build ../ce-platform-ios  --server=ce-platform.herokuapp.com",
     "build-dev": "run(){ meteor run ios-device -p $1 --mobile-server=http://$2:$1; }; run",
-    "test": "meteor test --driver-package practicalmeteor:mocha"
+    "test": "TEST_WATCH=1 meteor test --driver-package meteortesting:mocha",
+    "unittest": "meteor test --once --driver-package meteortesting:mocha",
+    "fulltest": "meteor test --once --full-app --driver-package meteortesting:mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary: Resolves #51 . Future PR will need to add the functionality that `checkIfNeedFailed` should have been doing to help with unsuccessful synchronous needs (detailed in the function docs)

Tests: Passes 13/14 tests passing
The only one that fails is
```
1) Availability Tests update availability:
    AssertionError: user not removed from need2: expected true to be false
```

In your command line, `npm run test` or `npm run unittest` 


