### PR TITLE
ADD: filter out location updates from a vehicle/bicycle

### DIFF
--- a/imports/startup/server/router.js
+++ b/imports/startup/server/router.js
@@ -24,7 +24,7 @@ Router.route('/api/geolocation', {where: 'server'})
 
     // FIXME(rlouie): Separate concerns to Affinder/Detectors to handle the logic for using activity info
     let not_traveling_on_bicycle_or_vehicle;
-    if ('activity' in Object.keys(location)) {
+    if ('activity' in location) {
       not_traveling_on_bicycle_or_vehicle = !((location.activity.type === "in_vehicle") || (location.activity.type === "on_bicycle"));
     } else {
       serverLog.call({message: `no activity data for ${uid}. defaulting to a value that allows location update`});
@@ -38,7 +38,7 @@ Router.route('/api/geolocation', {where: 'server'})
         serverLog.call({message: "triggering internal location update for: " + uid});
       });
     } else {
-      serverLog.call({ message: 'location update not triggered since user was null.' });
+      serverLog.call({ message: 'location update not triggered since user was null or user was on transit'});
     }
 
     this.response.writeHead(200, {'Content-Type': 'application/json'});

--- a/imports/startup/server/router.js
+++ b/imports/startup/server/router.js
@@ -21,10 +21,19 @@ Router.route('/api/geolocation', {where: 'server'})
 
     const uid = this.request.body.userId;
     const location = this.request.body.location;
-    // const activity = this.request.body.activity;
+
+    // FIXME(rlouie): Separate concerns to Affinder/Detectors to handle the logic for using activity info
+    let not_traveling_on_bicycle_or_vehicle;
+    if ('activity' in Object.keys(location)) {
+      not_traveling_on_bicycle_or_vehicle = !((location.activity.type === "in_vehicle") || (location.activity.type === "on_bicycle"));
+    } else {
+      serverLog.call({message: `no activity data for ${uid}. defaulting to a value that allows location update`});
+      not_traveling_on_bicycle_or_vehicle = true;
+    }
 
     // only do a location update if valid uid
-    if (uid !== null) {
+    // and if we are not traveling on a bicycle or in a vehicle
+    if ((uid !== null) && (not_traveling_on_bicycle_or_vehicle)) {
       onLocationUpdate(uid, location.coords.latitude, location.coords.longitude, function (uid) {
         serverLog.call({message: "triggering internal location update for: " + uid});
       });


### PR DESCRIPTION
Summary: If user is in a vehicle or a bicycle, their location updates won't be passed on to the rest of the Coodinator pipeline.   This makes some hacky progress towards a first milestone for issue #56 

__THINK ABOUT IMPLEMENTATION__
* During the study for data analysis, do we want to log the data when users are in transit?

Testing: __TODO: Really need our testers in cars to help judge this one__