### PR TITLE
Half Half Camera UI 1st Round of Fixes

### DIFF
--- a/imports/ui/pages/api_custom.html
+++ b/imports/ui/pages/api_custom.html
@@ -37,10 +37,26 @@
         padding-bottom: 4%;
       }
 
+      .glyphicon-medium {
+        font-size: 24px;
+      }
+
+      .glyphicon-large {
+        font-size: 32px;
+      }
+
+      .right-align {
+        float: right;
+      }
+
+      .navigation-buttons {
+        margin-bottom: 10px;
+      }
+
     </style>
   </head>
 
-  <div class="instruction">
+  <div id="instruction" class="instruction">
     {{this.toPass.instruction}}
     {{#let needImages=(mostRecentImageDyadForNeed this.images this.needName) }}
       {{#if (lengthEqual needImages 1) }}
@@ -53,14 +69,20 @@
         Frame the left half. Then somebody will frame the right half.
       {{/if}}
     {{/let}}
+    {{#if this.toPass.exampleImage}}
+      <div>
+        <u>Example to try</u>
+        <img style="width: 100%; margin-bottom: 10px" src="{{this.toPass.exampleImage}}"/>
+      </div>
+    {{/if}}
+    <button id="goToParticipate" class="btn btn-primary right-align">
+      <span>Open Camera</span><span class="glyphicon glyphicon-menu-right"></span>
+    </button>
   </div>
-  {{#if this.toPass.exampleImage}}
-    <div>
-      <u>Example to try</u>
-      <img style="width: 100%; margin-bottom: 10px" src="{{this.toPass.exampleImage}}"/>
-    </div>
-  {{/if}}
-  <form id="participate">
+  <form id="participate" style="display: none">
+    <button id="goToInstruction" type="button" class="btn btn-primary navigation-buttons">
+      <span class="glyphicon glyphicon-menu-left"></span><span>Instructions</span>
+    </button>
     <div id="cameraOverlay" class="camera-overlay">
       {{> loadingOverlay}}
       {{#let needImages=(mostRecentImageDyadForNeed this.images this.needName) }}
@@ -85,9 +107,6 @@
     <div class="camera-controls">
       <!-- LEAVE testImage button commented out!!! -->
       <!--<button type="button" id="testImage" class="left-control">Test</button>-->
-      <button type="button" id="startCamera" class="btn-borderless center-control">
-        <span class="glyphicon glyphicon-camera glyphicon-large"></span>
-      </button>
       <button type="button" id="takeHalfHalfPhoto" class="btn-borderless center-control" style="display: none">
         <span class="glyphicon glyphicon-record glyphicon-large"></span>
       </button>

--- a/imports/ui/pages/api_custom.html
+++ b/imports/ui/pages/api_custom.html
@@ -107,6 +107,9 @@
     <div class="camera-controls">
       <!-- LEAVE testImage button commented out!!! -->
       <!--<button type="button" id="testImage" class="left-control">Test</button>-->
+      <button type="button" id="takePhotoInProgress" class="btn-borderless center-control" style="display: none">
+        <span class="fa fa-spinner glyphicon-large"></span>
+      </button>
       <button type="button" id="takeHalfHalfPhoto" class="btn-borderless center-control" style="display: none">
         <span class="glyphicon glyphicon-record glyphicon-large"></span>
       </button>

--- a/imports/ui/pages/api_custom.js
+++ b/imports/ui/pages/api_custom.js
@@ -203,17 +203,20 @@ Template.halfhalfParticipate.events({
         CameraPreview.show();
       }
     } else {
-      // start CameraPreview instance running
-      if (typeof CameraPreview !== 'undefined') {
-        startCameraAtPreviewRect();
-        template.cameraStarted.set(true);
-      } else {
-        console.error("Could not access the CameraPreview")
-      }
-      // using an instance of jquery tied to current template scope
-      template.$(".fileinput-preview").hide();
-      template.imageSubmitReady.set(false);
-      toggleCameraControls('startCamera');
+      // Wait for the participate div to load before setting the location of the preview
+      Meteor.setTimeout(() => {
+        // start CameraPreview instance running
+        if (typeof CameraPreview !== 'undefined') {
+          startCameraAtPreviewRect();
+          template.cameraStarted.set(true);
+        } else {
+          console.error("Could not access the CameraPreview")
+        }
+        // using an instance of jquery tied to current template scope
+        template.$(".fileinput-preview").hide();
+        template.imageSubmitReady.set(false);
+        toggleCameraControls('startCamera');
+      }, 150);
     }
   },
   'click #goToInstruction'() {

--- a/imports/ui/pages/api_custom.js
+++ b/imports/ui/pages/api_custom.js
@@ -150,11 +150,14 @@ Template.halfhalfParticipate.onDestroyed(() => {
 Template.halfhalfParticipate.events({
   'click #takeHalfHalfPhoto'(event, template){
     if (typeof CameraPreview !== 'undefined') {
+      toggleCameraControls('takePhotoInProgress');
+
       CameraPreview.takePicture({
-        // dimensions of an iPhone 6s front-facing camera
+        // dimensions of an iPhone 6s front-facing camera are 960 1280
         // any larger dimensions displays the captured picture with significant lag
+        // reducing to 480 x 640 in an attempt to speed up webclient image processing
         // TODO(rlouie): test these parameters with many devices, whose supported photo sizes might make this not work
-        width: 960, height: 1280, quality: 85
+        width: 480, height: 640, quality: 85
       },function(imgData){
           let rect = getPreviewRect();
           b64CropLikeCordova(imgData, rect.width, rect.height, function(croppedImgUrl) {
@@ -164,7 +167,7 @@ Template.halfhalfParticipate.events({
             imagePreview.show();
             template.imageSubmitReady.set(true);
             CameraPreview.hide();
-            toggleCameraControls('stopCamera');
+            toggleCameraControls('takePhotoDone');
           });
       });
     } else {
@@ -270,13 +273,18 @@ const toggleCameraControls = function(mode) {
     document.getElementById('takeHalfHalfPhoto').style.display = "inline";
     document.getElementById('switchCamera').style.display = "inline";
   }
-  else if (mode === "stopCamera") {
-    document.getElementById('retakePhoto').style.display = "inline";
+  else if (mode === "takePhotoInProgress") {
+    document.getElementById('takePhotoInProgress').style.display = "inline";
     document.getElementById('takeHalfHalfPhoto').style.display = "none";
     document.getElementById('switchCamera').style.display = "none";
   }
+  else if (mode === "takePhotoDone") {
+    document.getElementById('takePhotoInProgress').style.display = "none";
+    document.getElementById('retakePhoto').style.display = "inline";
+  }
   else {
-    console.log("toggleCameraControls requires passing either 'startCamera' or 'stopCamera' as first parameter");
+    console.log("toggleCameraControls requires passing either 'startCamera' or 'takePhotoInProgress' or \
+                'takePhotoDone' as first parameter");
   }
 };
 

--- a/imports/ui/pages/participate.scss
+++ b/imports/ui/pages/participate.scss
@@ -68,14 +68,6 @@
     left: 95%;
     transform: translate(-95%, 0);
   }
-
-  .glyphicon-medium {
-    font-size: 24px;
-  }
-
-  .glyphicon-large {
-    font-size: 32px;
-  }
   // END halfhalfParticipate
 
   .fileinput {


### PR DESCRIPTION
Summary: Attempts at resolving #66 

Half Half Participate Interface Changes
- The instructions are on one page
- The participate half half camera is on another page
- Buttons on the two pages help switch between the two divs (implemented as a hide/show of each div, we never go to a different route)

This fixes janky issues that were present because
- Scrolling and updating the preview no longer is happening
- We aren't creating race conditions with starting/stopping the cordova camera preview (but instead just starting it once during the session, and hiding/showing when needed)
- For laggy operations on takePhoto, we improved this by 1) taking a smaller picture dimension so this process might be a little faster.  in reality, it doesn't feel all that faster 2) adding a loading icon so that the user knows that the slow camera is at least processing, before showing the takePhoto is done.

Testing: 
1. Tested with one Participate UI in which Instructions fit on page
2. Tested with one Participate UI in which Instructions didn't fit on the page [this necessitated using the Meteor.setTimeout before starting the camera preview]
3. Pressing in between the "Open Camera" and "Instructions" buttons very quickly would sometimes create a race condition when starting/stopping the camera. [this necessitated only starting the camera once, and then hiding/showing the preview to cut lag]

![img_7016](https://user-images.githubusercontent.com/5459644/43811169-d9a74d9a-9a80-11e8-8275-70d35ae5ede4.PNG)

![img_7017](https://user-images.githubusercontent.com/5459644/43811174-e0f15b18-9a80-11e8-8486-91b969f9e294.PNG)

![img_7018](https://user-images.githubusercontent.com/5459644/43811181-e89521c4-9a80-11e8-819b-f5c2a7eeed62.PNG)

