### PR TITLE
Renamed app to Collective Experiences within header

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,16 +83,12 @@ iron:url@1.1.0
 jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
-lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.1.20
 mdg:validated-method@1.1.0
 mdg:validation-error@0.5.1
 meteor@1.8.6
 meteor-base@1.3.0
-meteorhacks:picker@1.0.3
-meteortesting:browser-tests@1.0.0
-meteortesting:mocha@1.0.0
 meteortoys:toykit@3.0.4
 minifier-css@1.3.1
 minifier-js@2.3.5

--- a/imports/ui/layout/header.html
+++ b/imports/ui/layout/header.html
@@ -2,7 +2,7 @@
     <div class="navbar navbar-default navbar-fixed-top" role="navigation">
         <div class="container">
             <div class="navbar-header">
-                <a class="navbar-brand" href="/" style="color:white;">ce v1.1.0</a>
+                <a class="navbar-brand" href="/" style="color:white; font-size: smaller">Collective Experiences</a>
             </div>
             <ul class="nav navbar-nav" style="color:white !important;">
                 {{> loginButtons}}


### PR DESCRIPTION
Summary: Resolves #65 

Tests:  For many screen sizes and lengths of User Signin/Login Text, the navbar should not change size.

Normal User with <10 character user name, the logo fits.
![img_7032](https://user-images.githubusercontent.com/5459644/44005902-8fa3c4d0-9e40-11e8-9e09-485a60dd6d04.PNG)

We can simulate the smallest screen width devices through web dev tools. Here, several cases do not overlap.

<img width="282" alt="image" src="https://user-images.githubusercontent.com/5459644/44005935-43f23d36-9e41-11e8-95a5-b60a937628ac.png">

this change BREAKS long user names, on small devices.  For example,
<img width="279" alt="image" src="https://user-images.githubusercontent.com/5459644/44005946-734dc564-9e41-11e8-9b42-c1e833d61d5f.png">
