### PR TITLE
Page Logs for client actions!

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -82,12 +82,17 @@ iron:url@1.1.0
 jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
+lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.1.20
 mdg:validated-method@1.1.0
 mdg:validation-error@0.5.1
 meteor@1.8.6
 meteor-base@1.3.0
+meteorhacks:picker@1.0.3
+meteortesting:browser-tests@1.0.0
+meteortesting:mocha@1.1.1
+meteortesting:mocha-core@1.0.1
 meteortoys:toykit@3.0.4
 minifier-css@1.3.1
 minifier-js@2.3.5

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -82,17 +82,12 @@ iron:url@1.1.0
 jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
-lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.1.20
 mdg:validated-method@1.1.0
 mdg:validation-error@0.5.1
 meteor@1.8.6
 meteor-base@1.3.0
-meteorhacks:picker@1.0.3
-meteortesting:browser-tests@1.0.0
-meteortesting:mocha@1.0.1
-meteortesting:mocha-core@1.0.1
 meteortoys:toykit@3.0.4
 minifier-css@1.3.1
 minifier-js@2.3.5

--- a/imports/startup/client/notifications.js
+++ b/imports/startup/client/notifications.js
@@ -1,6 +1,7 @@
 import { Push } from 'meteor/raix:push';
 import { Router } from 'meteor/iron:router';
 import { log, serverLog } from '../../api/logs.js';
+import {Meteor} from "meteor/meteor";
 
 Push.Configure({
   android: {
@@ -32,6 +33,19 @@ Push.addListener('startup', (notification) => {
       bgGeo.start();
     }
 
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "opennotification",
+        params: {
+          pushListener: 'startup',
+          payload: notification.payload
+        }
+      };
+      Meteor.call('insertLog', dic);
+    }
+
     Router.go(notification.payload.route);
   }
 });
@@ -45,6 +59,19 @@ Push.addListener('message', (notification) => {
     if(bgGeo){
       bgGeo.stop();
       bgGeo.start();
+    }
+
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "opennotification",
+        params: {
+          pushListener: 'message',
+          payload: notification.payload
+        }
+      };
+      Meteor.call('insertLog', dic);
     }
 
     Router.go(notification.payload.route);

--- a/imports/startup/client/router.js
+++ b/imports/startup/client/router.js
@@ -45,6 +45,16 @@ Router.route('affordances', {
   path: '/affordances',
   template: 'affordances',
   before: function () {
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "affordances",
+        params: {}
+      };
+      Meteor.call('insertLog', dic);
+    }
+
     this.subscribe('avatars.all').wait();
     this.subscribe('users.all').wait();
     this.subscribe('locations.activeUser').wait();
@@ -63,6 +73,20 @@ Router.route('api.custom', {
   path: '/apicustom/:iid/:eid/:needName',
   template: 'api_custom',
   before: function () {
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "customparticipate",
+        params: {
+          iid: this.params.iid,
+          eid: this.params.eid,
+          needName: this.params.needName
+        }
+      };
+      Meteor.call('insertLog', dic);
+    }
+
     this.subscribe('experiences.single', this.params.eid).wait();
     this.subscribe('incidents.single', this.params.iid).wait();
     this.subscribe('locations.activeUser').wait();
@@ -91,16 +115,18 @@ Router.route('api.customresults', {
   path: '/apicustomresults/:iid/:eid',
   template: 'api_custom_results',
   before: function () {
-    let dic = {
-      uid: Meteor.userId(),
-      timestamp: Date.now(),
-      route: "customresults",
-      params: {
-        iid: this.params.iid,
-        eid: this.params.eid
-      }
-    };
-    Meteor.call('insertLog', dic); //TODO: fix this so if user not logged in doesn't freak out
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "customresults",
+        params: {
+          iid: this.params.iid,
+          eid: this.params.eid
+        }
+      };
+      Meteor.call('insertLog', dic);
+    }
     this.subscribe('images.activeIncident', this.params.iid).wait();
     this.subscribe('experiences.single', this.params.eid).wait();
     this.subscribe('submissions.activeIncident', this.params.iid).wait();
@@ -143,6 +169,17 @@ Router.route('api.customresults.admin', {
 
 Router.route('/', {
   name: 'home',
+  before: function() {
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "home",
+        params: {}
+      };
+      Meteor.call('insertLog', dic);
+    }
+  }
 });
 
 Router.route('participate.backdoor', {
@@ -208,6 +245,15 @@ Router.route('profile', {
   path: '/profile',
   template: 'profile',
   before: function () {
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "profile",
+        params: {}
+      };
+      Meteor.call('insertLog', dic);
+    }
     this.subscribe('incidents.pastUser').wait();
     this.subscribe('experiences.pastUser').wait();
     this.next();

--- a/imports/startup/client/router.js
+++ b/imports/startup/client/router.js
@@ -179,6 +179,7 @@ Router.route('/', {
       };
       Meteor.call('insertLog', dic);
     }
+    this.next();
   }
 });
 

--- a/imports/ui/components/active_experience.js
+++ b/imports/ui/components/active_experience.js
@@ -4,9 +4,28 @@ import { Template } from 'meteor/templating';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 
 import { Schema } from '../../api/schema.js';
+import {Meteor} from "meteor/meteor";
 
 Template.activeExperience.onCreated(function () {
   this.autorun(() => {
     this.subscribe('experiences.activeUser');
   })
+});
+
+Template.activeExperience.events({
+  'click .card-action': function() {
+    if (Meteor.userId()) {
+      let dic = {
+        uid: Meteor.userId(),
+        timestamp: Date.now(),
+        route: "home_to_customparticipate",
+        params: {
+          iid: this.iid,
+          eid: this.experience._id,
+          needName: this.needName
+        }
+      };
+      Meteor.call('insertLog', dic);
+    }
+  }
 });


### PR DESCRIPTION
Summary: Analysis was really hard when I only understood when someone was notified, and when someone submitted. However, I could not recreate other user actions including
- Opened the notification! We have route information too, which tells us if this notification sent them to home or directly to the participate page [This is added!]
- Opened the participate page (apicustom)! [This is added!]
- Clicked "Participate" on the Active Experience on the home page [This is added!]

Tests: 
- Notification opens: tested on Heroku Production with user logged in, and the logs show up as expected 
- Opened participate: logged in production
- Clicked on Participate: logged in production
- Tests when user is not logged in [i.e. through backdoor routes]: Does not log a false positive page log

This PR does not include logs for system actions in this process. These should be included in a future PR
- Users availabilities for certain needs are updated (availability_log should have added to availability, removed from availability)
- Users assignments to a need is updated (assignment_log should have assigned, and time decommissioned). Added to Assignments should be close duplicates of notified (although in cases where user has app open, they wont be notified but their experiences should be refreshed)

