### PR TITLE
Updating all location points, no longer prefilter on activity. Query …

### DIFF
--- a/imports/startup/server/router.js
+++ b/imports/startup/server/router.js
@@ -22,23 +22,13 @@ Router.route('/api/geolocation', {where: 'server'})
     const uid = this.request.body.userId;
     const location = this.request.body.location;
 
-    // FIXME(rlouie): Separate concerns to Affinder/Detectors to handle the logic for using activity info
-    let not_traveling_on_bicycle_or_vehicle;
-    if ('activity' in location) {
-      not_traveling_on_bicycle_or_vehicle = !((location.activity.type === "in_vehicle") || (location.activity.type === "on_bicycle"));
-    } else {
-      serverLog.call({message: `no activity data for ${uid}. defaulting to a value that allows location update`});
-      not_traveling_on_bicycle_or_vehicle = true;
-    }
-
     // only do a location update if valid uid
-    // and if we are not traveling on a bicycle or in a vehicle
-    if ((uid !== null) && (not_traveling_on_bicycle_or_vehicle)) {
+    if (uid !== null) {
       onLocationUpdate(uid, location, function (uid) {
         serverLog.call({message: "triggering internal location update for: " + uid});
       });
     } else {
-      serverLog.call({ message: 'location update not triggered since user was null or user was on transit'});
+      serverLog.call({ message: 'location update not triggered since user was null'});
     }
 
     this.response.writeHead(200, {'Content-Type': 'application/json'});


### PR DESCRIPTION
…place affordances only when not moving by car/bike. 

Obstacle: Sometimes a spurious location update would have incorrect activity data associated with it (e.g., when riding a bus, a location update gets triggered for the bus stop to pick up passengers, and retrieves affordances for a grocery store near the bus stop). Prior to this revision, that location update would register an affordance match; because the following points would be prefiltered because traveling in a vehicle, it seemed like the person had no location update since they were in front of the grocery store / bus stop.

Tests: while traveling on the bus, I observed location updates happening more frequently than every 60 seconds, which means that this false positive of caused by "no location update since in front of grocery store / bus stop" no longer happens.

