### PR TITLE
Host fontawesome files so theres never issues with getting the wrong …

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -56,3 +56,4 @@ useraccounts:iron-routing
 aldeed:template-extension
 useraccounts:bootstrap
 underscore
+fortawesome:fontawesome

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -64,6 +64,7 @@ es5-shim@4.8.0
 fetch@0.1.1
 force-ssl@1.1.0
 force-ssl-common@1.1.0
+fortawesome:fontawesome@4.7.0
 fourseven:scss@3.13.0
 geojson-utils@1.0.10
 hot-code-push@1.0.4

--- a/client/head.html
+++ b/client/head.html
@@ -25,7 +25,6 @@
 
   <!-- Other header information goes here. -->
   <!-- This will be propagated through all files. -->
-  <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
   <link href='https://fonts.googleapis.com/css?family=Montserrat' rel='stylesheet' type='text/css'>
   <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type='text/css'>
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">


### PR DESCRIPTION
…icons from CDN?

Summary:

Issue: Participate Screen (Camera Preview) has trident instead of camera icons 🔱⁉️
Bad Outcome: People don’t know which buttons to press for the camera screen
Bad Characteristic: Font Awesome is accessed through a CDN right now
Revised Characteristic: We host Font Awesome on the app, so the files are downloaded as assets.

Tests:
The camera has been working for me, and pre-testing for 10 days hasn't showed those icons in a while. So 🤞 ?