### PR TITLE
ParticipatingNow status more robust to inactivity

### DIFF
--- a/imports/api/Logging/participating_now_log.js
+++ b/imports/api/Logging/participating_now_log.js
@@ -1,0 +1,29 @@
+import { Mongo } from 'meteor/mongo';
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { Schema } from '../schema.js';
+
+export const ParticipatingNow_log = new Mongo.Collection('participating_now_log');
+
+Schema.ParticipatingNow_log = new SimpleSchema({
+  uid: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+    label: 'user id'
+  },
+  action: {
+    type: String,
+    label: 'are you "push" to or "pull" from participating now',
+  },
+  timestamp: {
+    type: Date,
+  },
+  iid: {
+    type: String,
+  },
+  needName: {
+    type: String
+  }
+});
+
+ParticipatingNow_log.attachSchema(Schema.ParticipatingNow_log);
+

--- a/imports/api/OCEManager/OCEs/experiences.js
+++ b/imports/api/OCEManager/OCEs/experiences.js
@@ -64,6 +64,7 @@ Schema.NeedType = new SimpleSchema({
     type: Number,
     optional: true
     // defaults to numberNeeded, like a semaphore.
+    // see needIsAvailableToParticipateNow in strategizer.js
   },
   notificationDelay: {
     type: Number,

--- a/imports/api/OpportunisticCoordinator/server/identifier.js
+++ b/imports/api/OpportunisticCoordinator/server/identifier.js
@@ -14,6 +14,7 @@ import {log, serverLog} from "../../logs";
 import {flattenAffordanceDict} from "../../UserMonitor/detectors/methods";
 import {Decommission_log} from "../../Logging/decommission_log";
 import {AddedToIncident_log} from "../../Logging/added_to_incident_log";
+import {ParticipatingNow_log} from "../../Logging/participating_now_log";
 
 
 export const getNeedObject = (iid, needName) => {
@@ -431,13 +432,22 @@ export const pushUserIntoParticipatingNow = (iid, needName, uid) => {
     },
     {
       $push: {
-        // note: this object is different than {"uid": uid, "place": place, "distance": distance}
-        "needUserMaps.$.users": {
-          "uid": uid
-        }
+        "needUserMaps.$.users": {"uid": uid }
       }
     }
   );
+
+  ParticipatingNow_log.insert({
+    uid: uid,
+    action: 'push',
+    timestamp: Date.now(),
+    iid: iid,
+    needName: needName
+  }, (err) => {
+    if (err) {
+      log.error(`Failed to insert to ParticipatingNow_log when pushing user to ParticipateNow: ${err}`);
+    }
+  });
 };
 
 
@@ -460,6 +470,18 @@ export const pullUserFromParticipatingNow = (iid, needName, uid) => {
       $pull: { "needUserMaps.$.users": {"uid" : uid } }
     }
   );
+
+  ParticipatingNow_log.insert({
+    uid: uid,
+    action: 'pull',
+    timestamp: Date.now(),
+    iid: iid,
+    needName: needName
+  }, (err) => {
+    if (err) {
+      log.error(`Failed to insert to ParticipatingNow_log when pulling user from ParticipateNow: ${err}`);
+    }
+  });
 };
 
 

--- a/imports/api/OpportunisticCoordinator/strategizer.js
+++ b/imports/api/OpportunisticCoordinator/strategizer.js
@@ -95,32 +95,25 @@ export const numberSubmissionsRemaining = (iid, needName) => {
 
 export const needIsAvailableToParticipateNow = (incident, needName) => {
   if (!incident) {
-    console.log(`Error in needAggregator: incident is null\n ${JSON.stringify(incident)}`);
+    console.error(`Error in needIsAvailableToParticipateNow: incident is null`);
     return;
   }
   if (!needName) {
-    console.log(`Error in needAggregator: needName is null`);
+    console.error(`Error in needIsAvailableToParticipateNow: needName is null`);
     return;
   }
   if (!incident.contributionTypes) {
-    console.log(`Error in needAggregator: incident does not have contribution types\n ${JSON.stringify(incident)}`);
+    console.error(`Error in needIsAvailableToParticipateNow: incident does not have contribution types\n ${JSON.stringify(incident)}`);
     return;
   }
   const needObject = incident.contributionTypes.find(need => need.needName == needName);
-  const numberNeeded = numberSubmissionsRemaining(incident._id, needName);
   const semaphoreMax = needObject.numberAllowedToParticipateAtSameTime ?
-    needObject.numberAllowedToParticipateAtSameTime : numberNeeded;
-  const resourcesStillAvailable = numberUsersParticipatingNow(incident._id, needName) < semaphoreMax;
+    needObject.numberAllowedToParticipateAtSameTime : numberSubmissionsRemaining(incident._id, needName);
+  const resourcesStillAvailable = usersParticipatingNow(incident._id, needName).length < semaphoreMax;
   return resourcesStillAvailable;
 };
 
-/**
- * numberUsersParticipatingNow
- *
- * @param iid
- * @param needName
- */
-export const numberUsersParticipatingNow = (iid, needName) => {
+export const usersParticipatingNow = (iid, needName) => {
   let participatingNowInIncident = ParticipatingNow.findOne({_id: iid});
   if (!participatingNowInIncident) {
     console.error(`Error in numberUsersParticipatingNow: no doc in ParticipatingNow found for iid ${iid}`);
@@ -135,6 +128,6 @@ export const numberUsersParticipatingNow = (iid, needName) => {
     console.error(`Error in numUsersParticipatingNow: needMap.users is not an array`);
     return;
   }
-  return needMap.users.length;
+  return needMap.users;
 };
 

--- a/imports/startup/server/fixtures.js
+++ b/imports/startup/server/fixtures.js
@@ -130,7 +130,7 @@ function createTestData(){
   log.info(`Populated ${ Meteor.users.find().count() } accounts`);
 
   // add detectors
-  Object.values(CONSTANTS.DETECTORS).forEach(function (value) {
+  Object.values(CONSTANTS.DETECTORS).forEach(function (value){
     Detectors.insert(value);
   });
   log.info(`Populated ${ Detectors.find().count() } detectors`);
@@ -172,7 +172,7 @@ function createTestData(){
   Meteor.users.update({
     _id: {$in: [uid1, uid2]}
   }, {
-    $set: { 'profile.staticAffordances': {"lovesGarrett": true } }
+    $set: { 'profile.staticAffordances': {"lovesGarrett": true, "knowsDTR": true} }
   }, {
     multi: true
   });

--- a/imports/ui/pages/api_custom.html
+++ b/imports/ui/pages/api_custom.html
@@ -1,5 +1,36 @@
 <template name="api_custom">
+  <head>
+    <style>
+      #emoji {
+        text-align: center;
+      }
+
+      #title {
+        text-align: center;
+        color: #333;
+      }
+
+      #empty-state-text {
+        padding-left: 15px;
+        padding-right: 15px;
+        text-align: center;
+        color: #888;
+      }
+
+      #empty-state {
+        padding-top: 42%;
+      }
+    </style>
+  </head>
+  {{#if renderWaiting}}
+    <div id="empty-state">
+      <h1 id="emoji">🤖🧠👀</h1>
+      <h4 id="title">Waiting for an unoccupied participate screen...</h4>
+      <p id="empty-state-text">Others are currently participating! So please be patient</p>
+    </div>
+  {{else}}
     {{> Template.dynamic template=data.experience.participateTemplate data=data}}
+  {{/if}}
 </template>
 
 <template name="uploadPhoto">

--- a/imports/ui/pages/dynamic_participate.js
+++ b/imports/ui/pages/dynamic_participate.js
@@ -60,6 +60,7 @@ Template.dynamicParticipate.onCreated(function() {
         return numberSubmissionsRemaining(this.iid, needB) - numberSubmissionsRemaining(this.iid, needA);
       };
       potentialNeedNames.sort(prioritizeHalfCompletedNeeds); // mutates
+      console.log('calling needIsAvailableToParticipateNow from dynamicParticipate.onCreated');
       potentialNeedNames = potentialNeedNames.filter(needName => needIsAvailableToParticipateNow(this.incident, needName));
 
       if (!potentialNeedNames.length) {

--- a/imports/ui/pages/participating_now_status.js
+++ b/imports/ui/pages/participating_now_status.js
@@ -1,0 +1,215 @@
+import {Meteor} from "meteor/meteor";
+import {Incidents} from "../../api/OCEManager/OCEs/experiences";
+import {ParticipatingNow} from "../../api/OpportunisticCoordinator/databaseHelpers";
+import {needIsAvailableToParticipateNow, usersParticipatingNow} from "../../api/OpportunisticCoordinator/strategizer";
+
+export const stateUpdatePullUserFromParticipatingNow = () => {
+  if (Meteor.userId() && Session.get('iid') && Session.get('needName')) {
+    Meteor.call('pullUserFromParticipatingNow', {
+      iid: Session.get('iid'),
+      needName: Session.get('needName'),
+      uid: Meteor.userId()
+    });
+    Session.set('iid', null);
+    Session.set('needName', null);
+    Session.set('renderWaiting', false);
+    Router.go('/');
+  }
+};
+
+export const checkParticipatingNow = () => {
+  const params = Router.current().params;
+  if (Incidents.find().count() && ParticipatingNow.find().count() && params.iid && params.needName) {
+    Session.set('iid', params.iid);
+    Session.set('needName', params.needName);
+
+    const incident = Incidents.findOne({_id: params.iid});
+    if (!incident) {
+      console.log(`could not find incident for iid ${params.iid}`);
+      return;
+    }
+
+    const activeUsers = usersParticipatingNow(params.iid, params.needName);
+    const userAlreadyParticipatingNow = activeUsers.find((x) => x.uid === Meteor.userId());
+    if (userAlreadyParticipatingNow) {
+      console.log('user is already participating now');
+      return; // dont render waiting, and no need to push the user into participating now
+    }
+
+    console.log('calling needIsAvailableToParticipateNow from api_custom.onCreated');
+    try {
+      let pn_avail = needIsAvailableToParticipateNow(incident, params.needName);
+      if (pn_avail === null) {
+        return;
+      } else if (pn_avail === false) {
+        Session.set('renderWaiting', true);
+        return;
+      }
+    } catch (e) {
+      console.log(e);
+      return;
+    }
+
+    Meteor.call('pushUserIntoParticipatingNow', {
+      iid: params.iid, needName: params.needName, uid: Meteor.userId()
+    });
+  }
+
+};
+
+/**
+ * Code for detecting page visibility, and whether the document has gone hidden
+ * Forked from...
+ * https://stackoverflow.com/questions/1060008/is-there-a-way-to-detect-if-a-browser-window-is-not-currently-active
+ */
+
+/**
+ Registers the handler to the event for the given object.
+ @param obj the object which will raise the event
+ @param evType the event type: click, keypress, mouseover, ...
+ @param fn the event handler function
+ @param isCapturing set the event mode (true = capturing event, false = bubbling event)
+ @return true if the event handler has been attached correctly
+ */
+export const addEvent = (obj, evType, fn, isCapturing) => {
+  if (isCapturing==null) isCapturing=false;
+  if (obj.addEventListener){
+    // Firefox
+    obj.addEventListener(evType, fn, isCapturing);
+    return true;
+  } else if (obj.attachEvent){
+    // MSIE
+    let r = obj.attachEvent('on'+evType, fn);
+    return r;
+  } else {
+    return false;
+  }
+};
+
+// register to the potential page visibility change
+addEvent(document, "potentialvisilitychange", function(event) {
+  // TODO(rlouie): not sure of this if-else (whether both branches are reached)
+  if (document.potentialHidden) {
+    console.log('Setting up in 2 minutes to pull from participating now');
+    Meteor.setTimeout(stateUpdatePullUserFromParticipatingNow, 120 * 1000)
+  }
+  else {
+    checkParticipatingNow();
+  }
+});
+
+// register to the W3C Page Visibility API
+let hidden=null;
+let visibilityChange=null;
+if (typeof document.mozHidden !== "undefined") {
+  hidden="mozHidden";
+  visibilityChange="mozvisibilitychange";
+} else if (typeof document.msHidden !== "undefined") {
+  hidden="msHidden";
+  visibilityChange="msvisibilitychange";
+} else if (typeof document.webkitHidden!=="undefined") {
+  hidden="webkitHidden";
+  visibilityChange="webkitvisibilitychange";
+} else if (typeof document.hidden !=="hidden") {
+  hidden="hidden";
+  visibilityChange="visibilitychange";
+}
+if (hidden!=null && visibilityChange!=null) {
+  addEvent(document, visibilityChange, function(event) {
+    // TODO(rlouie): not sure of this if-else (whether both branches are reached)
+    if (hidden) {
+      console.log('Setting up in 2 minutes to pull from participating now');
+      Meteor.setTimeout(stateUpdatePullUserFromParticipatingNow, 120 * 1000)
+    } else {
+      checkParticipatingNow();
+    }
+  });
+}
+
+
+let potentialPageVisibility = {
+  pageVisibilityChangeThreshold:3*3600, // in seconds
+  init:function() {
+    function setAsNotHidden() {
+      let dispatchEventRequired=document.potentialHidden;
+      document.potentialHidden=false;
+      document.potentiallyHiddenSince=0;
+      if (dispatchEventRequired) dispatchPageVisibilityChangeEvent();
+    }
+
+    function initPotentiallyHiddenDetection() {
+      if (!hasFocusLocal) {
+        // the window does not has the focus => check for  user activity in the window
+        lastActionDate=new Date();
+        if (timeoutHandler!=null) {
+          clearTimeout(timeoutHandler);
+        }
+        timeoutHandler = setTimeout(checkPageVisibility, potentialPageVisibility.pageVisibilityChangeThreshold*1000+100); // +100 ms to avoid rounding issues under Firefox
+      }
+    }
+
+    function dispatchPageVisibilityChangeEvent() {
+      var unifiedVisilityChangeEventDispatchAllowed=false;
+      let evt = document.createEvent("Event");
+      evt.initEvent("potentialvisilitychange", true, true);
+      document.dispatchEvent(evt);
+    }
+
+    function checkPageVisibility() {
+      let potentialHiddenDuration=(hasFocusLocal || lastActionDate==null?0:Math.floor((new Date().getTime()-lastActionDate.getTime())/1000));
+      document.potentiallyHiddenSince=potentialHiddenDuration;
+      if (potentialHiddenDuration>=potentialPageVisibility.pageVisibilityChangeThreshold && !document.potentialHidden) {
+        // page visibility change threshold raiched => raise the even
+        document.potentialHidden=true;
+        dispatchPageVisibilityChangeEvent();
+      }
+    }
+
+    let lastActionDate=null;
+    let hasFocusLocal=true;
+    let hasMouseOver=true;
+    document.potentialHidden=false;
+    document.potentiallyHiddenSince=0;
+    let timeoutHandler = null;
+
+    addEvent(document, "pageshow", function(event) {
+      // TODO(rlouie): not sure if this is relevant, since on pageshow, we are back on the home page
+      checkParticipatingNow();
+    });
+    addEvent(document, "pagehide", function(event) {
+      console.log('Setting up in 2 minutes to pull from participating now');
+      Meteor.setTimeout(stateUpdatePullUserFromParticipatingNow, 120 * 1000);
+    });
+    addEvent(window, "pageshow", function(event) {
+      // TODO(rlouie): not sure if this is relevant, since on pageshow, we are back on the home page
+      checkParticipatingNow();
+    });
+    addEvent(window, "pagehide", function(event) {
+      console.log('Setting up in 2 minutes to pull from participating now');
+      Meteor.setTimeout(stateUpdatePullUserFromParticipatingNow, 120 * 1000);
+    });
+    addEvent(document, "mousemove", function(event) {
+      lastActionDate=new Date();
+    });
+    addEvent(document, "mouseover", function(event) {
+      hasMouseOver=true;
+      setAsNotHidden();
+    });
+    addEvent(document, "mouseout", function(event) {
+      hasMouseOver=false;
+      initPotentiallyHiddenDetection();
+    });
+    addEvent(window, "blur", function(event) {
+      hasFocusLocal=false;
+      initPotentiallyHiddenDetection();
+    });
+    addEvent(window, "focus", function(event) {
+      hasFocusLocal=true;
+      setAsNotHidden();
+    });
+    setAsNotHidden();
+  }
+};
+
+potentialPageVisibility.pageVisibilityChangeThreshold=4; // 4 seconds for testing
+potentialPageVisibility.init();


### PR DESCRIPTION
Summary:
- pull from participating now when person who has hidden the window and
redirect to home page...
- but do it with a delay, since accessing the camera module also
activates hiding the Cerebro window

Tests:
- Tested with browser windows on laptop
- Tested with cordova apps with custom and external camera modules

Create 2 min timeouts to pull from participating now, to make sure accessing external camera modules doesnt trigger going back to the home page

Check if user is already participating, so as to not push when page is reactive