### PR TITLE
Detector link

### DIFF
--- a/imports/api/OCEManager/OCEs/methods.js
+++ b/imports/api/OCEManager/OCEs/methods.js
@@ -117,8 +117,8 @@ export const doesUserMatchNeed = (uid, affordances, iid, needName) => {
     serverLog.call({message: `doesUserMatchNeed: need not found for {needName: ${needName}, iid: ${iid}}`});
     return false;
   } else {
-    let detectorId = need.situation.detector;
-    return matchAffordancesWithDetector(affordances, detectorId);
+    let detectorUniqueKey = need.situation.detector;
+    return matchAffordancesWithDetector(affordances, detectorUniqueKey);
   }
 };
 

--- a/imports/api/OpportunisticCoordinator/server/executor.js
+++ b/imports/api/OpportunisticCoordinator/server/executor.js
@@ -38,11 +38,11 @@ export const runNeedsWithThresholdMet = (incidentsWithUsersToRun) => {
     let incident = Incidents.findOne(iid);
     let experience = Experiences.findOne(incident.eid);
 
-    // { [detectorId]: [need1, ...], ...}
+    // { [detectorUniqueKey]: [need1, ...], ...}
     let needNamesBinnedByDetector = needAggregator(incident);
     let assignedNeedNames = Object.keys(needUserMapping);
 
-    _.forEach(needNamesBinnedByDetector, (commonDetectorNeedNames, detectorId) => {
+    _.forEach(needNamesBinnedByDetector, (commonDetectorNeedNames, detectorUniqueKey) => {
 
       // might have to distinguish what is logged done when its not half half vs not.
       // maybe use a "strategy" class model

--- a/imports/api/OpportunisticCoordinator/server/executor.tests.js
+++ b/imports/api/OpportunisticCoordinator/server/executor.tests.js
@@ -15,12 +15,12 @@ describe('Executor - Half Half Need when User is Assigned to "Need 1" and "Need 
   const distance = null;
   const needName1 = 'Rainy 1';
   const needName2 = 'Rainy 2';
-  const detectorId = Random.id();
+  const detectorUniqueKey = Random.id();
   const numberNeeded = 2;
   const halfhalfNeedTemplate = {
     needName: null,
     situation: {
-      detector: detectorId,
+      detector: detectorUniqueKey,
       number: 1
     },
     numberNeeded: numberNeeded,

--- a/imports/api/OpportunisticCoordinator/server/strategizer.tests.js
+++ b/imports/api/OpportunisticCoordinator/server/strategizer.tests.js
@@ -254,12 +254,12 @@ describe('Half Half Rainy Need - with [userA, userB] matching the requirements o
   const distance = null;
   const needName1 = 'Rainy 1';
   const needName2 = 'Rainy 2';
-  const detectorId = Random.id();
+  const detectorUniqueKey = Random.id();
   const numberNeeded = 2;
   const halfhalfNeedTemplate = {
       needName: null,
       situation: {
-        detector: detectorId,
+        detector: detectorUniqueKey,
         number: 1
       },
       numberNeeded: numberNeeded,
@@ -426,12 +426,12 @@ describe('Dynamic Loading of Exact Participate Need - needAggregator', () => {
   const eid = Random.id();  // doesn't really matter
   const needName1 = 'Rainy 1';
   const needName2 = 'Rainy 2';
-  const detectorId = Random.id();
+  const detectorUniqueKey = Random.id();
   const numberNeeded = 2;
   const halfhalfNeedTemplate = {
     needName: null,
     situation: {
-      detector: detectorId,
+      detector: detectorUniqueKey,
       number: 1
     },
     numberNeeded: numberNeeded,
@@ -464,7 +464,7 @@ describe('Dynamic Loading of Exact Participate Need - needAggregator', () => {
 
     chai.assert(JSON.stringify(res),
                 JSON.stringify({
-                  [detectorId]: [needName1, needName2]
+                  [detectorUniqueKey]: [needName1, needName2]
                 }))
   });
 });

--- a/imports/api/Testing/createNewExperiences.js
+++ b/imports/api/Testing/createNewExperiences.js
@@ -146,7 +146,7 @@ function createNewSpookyStorytime() {
   };
 
   let places = ["night", "niceish_day", "restaurant", "sunset", "coffee"];
-  let detectorIds = [
+  let detectorUniqueKeys = [
     "Dw9z8eTBvvF6EeqaR",
     "eqsBY5BBRZsFWfsS4",
     "Hewrfn8R87Z9EfjKh",
@@ -162,7 +162,7 @@ function createNewSpookyStorytime() {
     newVars.push("var participatedInSpookyStorytime;");
 
     let det = {
-      _id: detectorIds[i],
+      _id: detectorUniqueKeys[i],
       description: CONSTANTS.DETECTORS[place].description + "_SpookyStorytime",
       variables: newVars,
       rules: [
@@ -289,7 +289,7 @@ function createNewSpookyNevilleStorytime() {
   };
 
   let places = ["night", "niceish_day", "restaurant", "coffee"];
-  let detectorIds = [
+  let detectorUniqueKeys = [
     "F8YqP3AEbyguQMJ9i",
     "ueBZrF5mCRrcFBc8g",
     "yxQP8QrCdAWakjMaY",
@@ -303,7 +303,7 @@ function createNewSpookyNevilleStorytime() {
     newVars.push("var participatedInSpookyHarryStorytime;");
 
     let det = {
-      _id: detectorIds[i],
+      _id: detectorUniqueKeys[i],
       description:
         CONSTANTS.DETECTORS[place].description + "_SpookyHarryStorytime",
       variables: newVars,

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -727,13 +727,7 @@ let DETECTORS = {
 };
 
 export const getDetectorId = (detector) => {
-  let db_detector = Detectors.findOne({description: detector.description});
-  if (db_detector) {
-    console.log(JSON.stringify(db_detector));
-    return db_detector._id;
-  } else {
-    return detector._id;
-  }
+  return detector.description;
 };
 
 Meteor.methods({
@@ -1827,7 +1821,7 @@ const addStaticAffordanceToDetector = function(staticAffordance, detectorKey) {
  */
 const addStaticAffordanceToNeeds = function(staticAffordance, contributionTypes) {
   return _.map(contributionTypes, (need) => {
-    const detectorKey = _.keys(DETECTORS).find(key => DETECTORS[key]._id === need.situation.detector);
+    const detectorKey = _.keys(DETECTORS).find(key => getDetectorId(DETECTORS[key]) === need.situation.detector);
     if (!detectorKey) {
       throw `Exception in addStaticAffordanceToNeeds: could not find corresponding detector for ${JSON.stringify(need)}`
     }
@@ -2904,7 +2898,7 @@ let EXPERIENCES = {
     contributionTypes: [{
       needName: 'beer',
       situation: {
-        detector: DETECTORS.beer._id,
+        detector: getDetectorId(DETECTORS.beer),
         number: '1'
       },
       toPass: {
@@ -2915,7 +2909,7 @@ let EXPERIENCES = {
     }, {
       needName: 'greenProduce',
       situation: {
-        detector: DETECTORS.produce._id,
+        detector: getDetectorId(DETECTORS.produce),
         number: '1'
       },
       toPass: {
@@ -2927,7 +2921,7 @@ let EXPERIENCES = {
     }, {
       needName: 'coins',
       situation: {
-        detector: DETECTORS.drugstore._id,
+        detector: getDetectorId(DETECTORS.drugstore),
         number: '1'
       },
       toPass: {
@@ -2938,7 +2932,7 @@ let EXPERIENCES = {
     }, {
       needName: 'leprechaun',
       situation: {
-        detector: DETECTORS.costume_store._id,
+        detector: getDetectorId(DETECTORS.costume_store),
         number: '1'
       },
       toPass: {
@@ -2949,7 +2943,7 @@ let EXPERIENCES = {
     }, {
       needName: 'irishSign',
       situation: {
-        detector: DETECTORS.irish._id,
+        detector: getDetectorId(DETECTORS.irish),
         number: '1'
       },
       toPass: {
@@ -2960,7 +2954,7 @@ let EXPERIENCES = {
     }, {
       needName: 'trimmings',
       situation: {
-        detector: DETECTORS.hair_salon._id,
+        detector: getDetectorId(DETECTORS.hair_salon),
         number: '1'
       },
       toPass: {
@@ -2971,7 +2965,7 @@ let EXPERIENCES = {
     }, {
       needName: 'liquidGold',
       situation: {
-        detector: DETECTORS.gas_station._id,
+        detector: getDetectorId(DETECTORS.gas_station),
         number: '1'
       },
       toPass: {
@@ -2982,7 +2976,7 @@ let EXPERIENCES = {
     }, {
       needName: 'potOfGold',
       situation: {
-        detector: DETECTORS.bank._id,
+        detector: getDetectorId(DETECTORS.bank),
         number: '1'
       },
       toPass: {
@@ -2993,7 +2987,7 @@ let EXPERIENCES = {
     }, {
       needName: 'rainbow',
       situation: {
-        detector: DETECTORS.rainbow._id,
+        detector: getDetectorId(DETECTORS.rainbow),
         number: '1'
       },
       toPass: {

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -3,11 +3,9 @@ import { Meteor } from "meteor/meteor";
 import { Submissions } from "../OCEManager/currentNeeds";
 
 import { addContribution } from '../OCEManager/OCEs/methods';
-import {Detectors} from "../UserMonitor/detectors/detectors";
+import {getDetectorId} from "../UserMonitor/detectors/methods";
 import {notify, notifyUsersInIncident, notifyUsersInNeed} from "../OpportunisticCoordinator/server/noticationMethods";
 import {Incidents} from "../OCEManager/OCEs/experiences";
-import {Schema} from "../schema";
-import {serverLog} from "../logs";
 
 let LOCATIONS = {
   'park': {
@@ -726,27 +724,6 @@ let DETECTORS = {
   }
 };
 
-export const getDetectorId = (detector) => {
-  return detector.description;
-};
-
-Meteor.methods({
-  getDetectorId({name}) {
-    new SimpleSchema({
-      name: { type: String }
-    }).validate({name});
-
-    if (!(name in CONSTANTS.DETECTORS)) {
-      throw new Meteor.Error('getDetectorId.keynotfound',
-        `Detector by the name '${name}' was not found in CONSTANTS.DETECTORS`);
-    }
-
-    console.log('CONSTANTS.DETECTORS: ' + CONSTANTS.DETECTORS[name]._id);
-    console.log('db.detectors preferably: ' + getDetectorId(CONSTANTS.DETECTORS[name]))
-
-  }
-});
-
 /**
  * Create Storytime Helper.
  *
@@ -1257,7 +1234,7 @@ function createBumped() {
         let need = {
           needName: place[0] + relationship + i,
           situation: {
-            detector: detector._id,
+            detector: getDetectorId(detector),
             number: '2'
           },
           toPass: {

--- a/imports/api/Testing/testingconstants.js
+++ b/imports/api/Testing/testingconstants.js
@@ -3,7 +3,7 @@ import { Meteor } from "meteor/meteor";
 import { Submissions } from "../OCEManager/currentNeeds";
 
 import { addContribution } from '../OCEManager/OCEs/methods';
-import {getDetectorId} from "../UserMonitor/detectors/methods";
+import {getDetectorUniqueKey} from "../UserMonitor/detectors/methods";
 import {notify, notifyUsersInIncident, notifyUsersInNeed} from "../OpportunisticCoordinator/server/noticationMethods";
 import {Incidents} from "../OCEManager/OCEs/experiences";
 
@@ -733,7 +733,7 @@ let DETECTORS = {
 function createStorytime(version) {
   // setup places and detectors for storytime
   let places = ["niceish_day", "beer", "train", "forest", "dinning_hall", "castle", "field", "gym"];
-  let detectorIds = places.map((x) => { return Random.id(); });
+  let detectorUniqueKeys = places.map((x) => { return Random.id(); });
   let detectorNames = [];
   let dropdownText = [
     'Swirling Clouds',
@@ -767,16 +767,16 @@ function createStorytime(version) {
     detectorNames.push(detectorName);
 
     DETECTORS[detectorName] = {
-      '_id': detectorIds[i],
+      '_id': detectorUniqueKeys[i],
       'description': `${DETECTORS[place].description} storytime${version} mechanismRich`,
       'variables': newVars,
       'rules': newRules
     };
   });
 
-  // Don't assume the Random detectorIds we created actually exist
-  detectorIds = detectorNames.map((name) => { return getDetectorId(DETECTORS[name]); });
-  let DROPDOWN_OPTIONS = _.zip(dropdownText, detectorIds);
+  // Don't assume the Random detectorUniqueKeys we created actually exist
+  detectorUniqueKeys = detectorNames.map((name) => { return getDetectorUniqueKey(DETECTORS[name]); });
+  let DROPDOWN_OPTIONS = _.zip(dropdownText, detectorUniqueKeys);
   // create story starting point
   let sentences = [
     'Ron looked up at the clouds swirling above him.',
@@ -824,7 +824,7 @@ function createStorytime(version) {
     // HACKY TEMPLATE DYNAMIC CODE GENERATION
     let options = eval('${JSON.stringify(DROPDOWN_OPTIONS)}');
 
-    let [situation, detectorId] = options.find(function(x) {
+    let [situation, detectorUniqueKey] = options.find(function(x) {
       return x[1] === affordance;
     });
 
@@ -919,7 +919,7 @@ const createStorytimeImproved = (group, version) => {
 
   // setup places and detectors for storytime
   let places = ["niceish_day", "bar", "train", "forest", "restaurant", "gym"];
-  let detectorIds = places.map((x) => { return Random.id(); });
+  let detectorUniqueKeys = places.map((x) => { return Random.id(); });
   let detectorNames = [];
   let dropdownText = [
     'Swirling Clouds',
@@ -967,18 +967,18 @@ const createStorytimeImproved = (group, version) => {
     detectorNames.push(detectorName);
 
     DETECTORS[detectorName] = {
-      '_id': detectorIds[i],
+      '_id': detectorUniqueKeys[i],
       'description': `${DETECTORS[place].description} storytime ${knowsGroup}`,
       'variables': newVars,
       'rules': newRules
     };
   });
 
-  // Don't assume the Random detectorIds we created actually exist
-  detectorIds = detectorNames.map((name) => { return getDetectorId(DETECTORS[name]); });
-  let DROPDOWN_OPTIONS = _.zip(dropdownText, detectorIds);
-  let NOTIF_SUBJECT_OPTIONS = _.zip(notificationSubjects, detectorIds);
-  let NOTIF_TEXT_OPTIONS = _.zip(notificationTexts, detectorIds);
+  // Don't assume the Random detectorUniqueKeys we created actually exist
+  detectorUniqueKeys = detectorNames.map((name) => { return getDetectorUniqueKey(DETECTORS[name]); });
+  let DROPDOWN_OPTIONS = _.zip(dropdownText, detectorUniqueKeys);
+  let NOTIF_SUBJECT_OPTIONS = _.zip(notificationSubjects, detectorUniqueKeys);
+  let NOTIF_TEXT_OPTIONS = _.zip(notificationTexts, detectorUniqueKeys);
 
   // create story starting point
   let sentences = [
@@ -1023,7 +1023,7 @@ const createStorytimeImproved = (group, version) => {
     let notification_subject_options = eval('${JSON.stringify(NOTIF_SUBJECT_OPTIONS)}');
     let notification_text_options = eval('${JSON.stringify(NOTIF_TEXT_OPTIONS)}');
 
-    let [situation, detectorId] = options.find(function(x) {
+    let [situation, detectorUniqueKey] = options.find(function(x) {
       return x[1] === affordance;
     });
     let [notificationSubject, _1] = notification_subject_options.find(function(x) {
@@ -1142,7 +1142,7 @@ const createIndependentStorybook = () => {
         return {
           needName: situation,
           situation: {
-            detector: getDetectorId(DETECTORS[place]),
+            detector: getDetectorUniqueKey(DETECTORS[place]),
             number: '1',
           },
           toPass: {
@@ -1234,7 +1234,7 @@ function createBumped() {
         let need = {
           needName: place[0] + relationship + i,
           situation: {
-            detector: getDetectorId(detector),
+            detector: getDetectorUniqueKey(detector),
             number: '2'
           },
           toPass: {
@@ -1798,12 +1798,12 @@ const addStaticAffordanceToDetector = function(staticAffordance, detectorKey) {
  */
 const addStaticAffordanceToNeeds = function(staticAffordance, contributionTypes) {
   return _.map(contributionTypes, (need) => {
-    const detectorKey = _.keys(DETECTORS).find(key => getDetectorId(DETECTORS[key]) === need.situation.detector);
+    const detectorKey = _.keys(DETECTORS).find(key => getDetectorUniqueKey(DETECTORS[key]) === need.situation.detector);
     if (!detectorKey) {
       throw `Exception in addStaticAffordanceToNeeds: could not find corresponding detector for ${JSON.stringify(need)}`
     }
     const newDetectorKey = addStaticAffordanceToDetector(staticAffordance, detectorKey);
-    need.situation.detector = getDetectorId(DETECTORS[newDetectorKey]);
+    need.situation.detector = getDetectorUniqueKey(DETECTORS[newDetectorKey]);
     return need;
   });
 };
@@ -2029,7 +2029,7 @@ let EXPERIENCES = {
       // needName MUST have structure "My Need Name XYZ"
       needName: 'Hand Silhouette 1',
       situation: {
-        detector: getDetectorId(DETECTORS.sunny),
+        detector: getDetectorUniqueKey(DETECTORS.sunny),
         number: '1'
       },
       toPass: {
@@ -2058,7 +2058,7 @@ let EXPERIENCES = {
       notificationSubject: 'Inside a grocery store?',
       notificationText: 'Share an experience with others who are also grocery shopping',
       situation: {
-        detector: getDetectorId(DETECTORS.grocery),
+        detector: getDetectorUniqueKey(DETECTORS.grocery),
         number: '1'
       },
       toPass: {
@@ -2087,7 +2087,7 @@ let EXPERIENCES = {
       notificationSubject: 'Inside a coffee shop?',
       notificationText: 'Share an experience with others who are also at a coffee shop',
       situation: {
-        detector: getDetectorId(DETECTORS.coffee),
+        detector: getDetectorUniqueKey(DETECTORS.coffee),
         number: '1'
       },
       toPass: {
@@ -2115,7 +2115,7 @@ let EXPERIENCES = {
       notificationSubject: 'Drinking at a bar?',
       notificationText: 'Share an experience with others who are also drinking at a bar',
       situation: {
-        detector: getDetectorId(DETECTORS.bar),
+        detector: getDetectorUniqueKey(DETECTORS.bar),
         number: '1'
       },
       toPass: {
@@ -2142,7 +2142,7 @@ let EXPERIENCES = {
   //     // needName MUST have structure "My Need Name XYZ"
   //     needName: 'Itadakimasu 1',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.eating_japanese),
+  //       detector: getDetectorUniqueKey(DETECTORS.eating_japanese),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2170,7 +2170,7 @@ let EXPERIENCES = {
       notificationSubject: 'Visiting a place of worship?',
       notificationText: 'Share an experience with others who are also visiting a place of worship',
       situation: {
-        detector: getDetectorId(DETECTORS.castle),
+        detector: getDetectorUniqueKey(DETECTORS.castle),
         number: '1'
       },
       toPass: {
@@ -2199,7 +2199,7 @@ let EXPERIENCES = {
       notificationSubject: 'Can you see the sunset?',
       notificationText: 'Share an experience with others who are also watching the sunset',
       situation: {
-        detector: getDetectorId(DETECTORS.sunset),
+        detector: getDetectorUniqueKey(DETECTORS.sunset),
         number: '1'
       },
       toPass: {
@@ -2228,7 +2228,7 @@ let EXPERIENCES = {
       notificationSubject: 'Eating at an asian restaurant?',
       notificationText: 'Share an experience with others who are also eating asian food',
       situation: {
-        detector: getDetectorId(DETECTORS.eating_with_chopsticks),
+        detector: getDetectorUniqueKey(DETECTORS.eating_with_chopsticks),
         number: '1'
       },
       toPass: {
@@ -2257,7 +2257,7 @@ let EXPERIENCES = {
       notificationSubject: 'Are you at a library?',
       notificationText: 'Share an experience with others who are also at the library',
       situation: {
-        detector: getDetectorId(DETECTORS.library),
+        detector: getDetectorUniqueKey(DETECTORS.library),
         number: '1'
       },
       toPass: {
@@ -2284,7 +2284,7 @@ let EXPERIENCES = {
   //     // needName MUST have structure "My Need Name XYZ"
   //     needName: 'Hold a plant 1',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.forest),
+  //       detector: getDetectorUniqueKey(DETECTORS.forest),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2310,7 +2310,7 @@ let EXPERIENCES = {
   //     // needName MUST have structure "My Need Name XYZ"
   //     needName: 'Feet to the trees 1',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.forest),
+  //       detector: getDetectorUniqueKey(DETECTORS.forest),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2338,7 +2338,7 @@ let EXPERIENCES = {
       notificationSubject: 'Are you at a park?',
       notificationText: 'Share an experience with others who are also at a park',
       situation: {
-        detector: getDetectorId(DETECTORS.forest),
+        detector: getDetectorUniqueKey(DETECTORS.forest),
         number: '1'
       },
       toPass: {
@@ -2367,7 +2367,7 @@ let EXPERIENCES = {
       notificationSubject: 'Are you outside while its raining?',
       notificationText: 'Share an experience with others who are enjoying or enduring the rain',
       situation: {
-        detector: getDetectorId(DETECTORS.rainy),
+        detector: getDetectorUniqueKey(DETECTORS.rainy),
         number: '1'
       },
       toPass: {
@@ -2394,7 +2394,7 @@ let EXPERIENCES = {
   //     // needName MUST have structure "My Need Name XYZ"
   //     needName: "Slice of 'Za 1",
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.eating_pizza),
+  //       detector: getDetectorUniqueKey(DETECTORS.eating_pizza),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2420,7 +2420,7 @@ let EXPERIENCES = {
   //     // needName MUST have structure "My Need Name XYZ"
   //     needName: "Want cream with that 1",
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.coffee), // any place that has cups (cafes + bars + restaurants)
+  //       detector: getDetectorUniqueKey(DETECTORS.coffee), // any place that has cups (cafes + bars + restaurants)
   //       number: '1'
   //     },
   //     toPass: {
@@ -2446,7 +2446,7 @@ let EXPERIENCES = {
   //     // needName MUST have structure "My Need Name XYZ"
   //     needName: "Share a plate 1", // bowl? Plate?  (basically all restaurants)
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.restaurant),
+  //       detector: getDetectorUniqueKey(DETECTORS.restaurant),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2473,7 +2473,7 @@ let EXPERIENCES = {
       notificationSubject: 'Eating at a restaurant?',
       notificationText: 'Share an experience with others who are enjoying big bites of their meal',
       situation: {
-        detector: getDetectorId(DETECTORS.big_bite_restaurant),
+        detector: getDetectorUniqueKey(DETECTORS.big_bite_restaurant),
         number: '1'
       },
       toPass: {
@@ -2512,7 +2512,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Sunny Days',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.sunny),
+  //       detector: getDetectorUniqueKey(DETECTORS.sunny),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2537,7 +2537,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Feed yourself',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.grocery),
+  //       detector: getDetectorUniqueKey(DETECTORS.grocery),
   //       number: 1
   //     },
   //     toPass: {
@@ -2562,7 +2562,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Cafe Days',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.coffee),
+  //       detector: getDetectorUniqueKey(DETECTORS.coffee),
   //       number: 1
   //     },
   //     toPass: {
@@ -2587,7 +2587,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Hit the Bars',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.bar),
+  //       detector: getDetectorUniqueKey(DETECTORS.bar),
   //       number: 1
   //     },
   //     toPass: {
@@ -2612,7 +2612,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Eating Japanese Food',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.eating_japanese),
+  //       detector: getDetectorUniqueKey(DETECTORS.eating_japanese),
   //       number: 1
   //     },
   //     toPass: {
@@ -2637,7 +2637,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Religious Worship',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.castle),
+  //       detector: getDetectorUniqueKey(DETECTORS.castle),
   //       number: 1
   //     },
   //     toPass: {
@@ -2662,7 +2662,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Catch the sunset',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.sunset),
+  //       detector: getDetectorUniqueKey(DETECTORS.sunset),
   //       number: 1
   //     },
   //     toPass: {
@@ -2687,7 +2687,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Eating Asian Food',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.eating_with_chopsticks),
+  //       detector: getDetectorUniqueKey(DETECTORS.eating_with_chopsticks),
   //       number: 1
   //     },
   //     toPass: {
@@ -2712,7 +2712,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Reading a book',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.library),
+  //       detector: getDetectorUniqueKey(DETECTORS.library),
   //       number: 1
   //     },
   //     toPass: {
@@ -2737,7 +2737,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'I love parks',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.forest),
+  //       detector: getDetectorUniqueKey(DETECTORS.forest),
   //       number: 1
   //     },
   //     toPass: {
@@ -2762,7 +2762,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: 'Rainy Day',
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.rainy),
+  //       detector: getDetectorUniqueKey(DETECTORS.rainy),
   //       number: 1
   //     },
   //     toPass: {
@@ -2787,7 +2787,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: "Eating some 'Za",
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.eating_pizza),
+  //       detector: getDetectorUniqueKey(DETECTORS.eating_pizza),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2812,7 +2812,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: "Eating out",
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.restaurant),
+  //       detector: getDetectorUniqueKey(DETECTORS.restaurant),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2837,7 +2837,7 @@ let EXPERIENCES = {
   //   contributionTypes: addStaticAffordanceToNeeds('mechanismPoor', [{
   //     needName: "Eating Big Bites",
   //     situation: {
-  //       detector: getDetectorId(DETECTORS.big_bite_restaurant),
+  //       detector: getDetectorUniqueKey(DETECTORS.big_bite_restaurant),
   //       number: '1'
   //     },
   //     toPass: {
@@ -2875,7 +2875,7 @@ let EXPERIENCES = {
     contributionTypes: [{
       needName: 'beer',
       situation: {
-        detector: getDetectorId(DETECTORS.beer),
+        detector: getDetectorUniqueKey(DETECTORS.beer),
         number: '1'
       },
       toPass: {
@@ -2886,7 +2886,7 @@ let EXPERIENCES = {
     }, {
       needName: 'greenProduce',
       situation: {
-        detector: getDetectorId(DETECTORS.produce),
+        detector: getDetectorUniqueKey(DETECTORS.produce),
         number: '1'
       },
       toPass: {
@@ -2898,7 +2898,7 @@ let EXPERIENCES = {
     }, {
       needName: 'coins',
       situation: {
-        detector: getDetectorId(DETECTORS.drugstore),
+        detector: getDetectorUniqueKey(DETECTORS.drugstore),
         number: '1'
       },
       toPass: {
@@ -2909,7 +2909,7 @@ let EXPERIENCES = {
     }, {
       needName: 'leprechaun',
       situation: {
-        detector: getDetectorId(DETECTORS.costume_store),
+        detector: getDetectorUniqueKey(DETECTORS.costume_store),
         number: '1'
       },
       toPass: {
@@ -2920,7 +2920,7 @@ let EXPERIENCES = {
     }, {
       needName: 'irishSign',
       situation: {
-        detector: getDetectorId(DETECTORS.irish),
+        detector: getDetectorUniqueKey(DETECTORS.irish),
         number: '1'
       },
       toPass: {
@@ -2931,7 +2931,7 @@ let EXPERIENCES = {
     }, {
       needName: 'trimmings',
       situation: {
-        detector: getDetectorId(DETECTORS.hair_salon),
+        detector: getDetectorUniqueKey(DETECTORS.hair_salon),
         number: '1'
       },
       toPass: {
@@ -2942,7 +2942,7 @@ let EXPERIENCES = {
     }, {
       needName: 'liquidGold',
       situation: {
-        detector: getDetectorId(DETECTORS.gas_station),
+        detector: getDetectorUniqueKey(DETECTORS.gas_station),
         number: '1'
       },
       toPass: {
@@ -2953,7 +2953,7 @@ let EXPERIENCES = {
     }, {
       needName: 'potOfGold',
       situation: {
-        detector: getDetectorId(DETECTORS.bank),
+        detector: getDetectorUniqueKey(DETECTORS.bank),
         number: '1'
       },
       toPass: {
@@ -2964,7 +2964,7 @@ let EXPERIENCES = {
     }, {
       needName: 'rainbow',
       situation: {
-        detector: getDetectorId(DETECTORS.rainbow),
+        detector: getDetectorUniqueKey(DETECTORS.rainbow),
         number: '1'
       },
       toPass: {
@@ -3142,7 +3142,7 @@ let CHI20_DTR_EXPERIENCES =  {
       // needName MUST have structure "My Need Name XYZ"
       needName: 'Hand Silhouette 1',
       situation: {
-        detector: getDetectorId(DETECTORS.sunny),
+        detector: getDetectorUniqueKey(DETECTORS.sunny),
         number: '1'
       },
       toPass: {
@@ -3172,7 +3172,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Inside a grocery store?',
       notificationText: 'Share an experience with others who are also grocery shopping',
       situation: {
-        detector: getDetectorId(DETECTORS.grocery),
+        detector: getDetectorUniqueKey(DETECTORS.grocery),
         number: '1'
       },
       toPass: {
@@ -3202,7 +3202,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Drinking at a bar?',
       notificationText: 'Share an experience with others who are also drinking at a bar',
       situation: {
-        detector: getDetectorId(DETECTORS.bar),
+        detector: getDetectorUniqueKey(DETECTORS.bar),
         number: '1'
       },
       toPass: {
@@ -3232,7 +3232,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Visiting a place of worship?',
       notificationText: 'Share an experience with others who are also visiting a place of worship',
       situation: {
-        detector: getDetectorId(DETECTORS.castle),
+        detector: getDetectorUniqueKey(DETECTORS.castle),
         number: '1'
       },
       toPass: {
@@ -3262,7 +3262,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Can you see the sunset?',
       notificationText: 'Share an experience with others who are also watching the sunset',
       situation: {
-        detector: getDetectorId(DETECTORS.sunset),
+        detector: getDetectorUniqueKey(DETECTORS.sunset),
         number: '1'
       },
       toPass: {
@@ -3292,7 +3292,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Eating at an asian restaurant?',
       notificationText: 'Share an experience with others who are also eating asian food',
       situation: {
-        detector: getDetectorId(DETECTORS.eating_with_chopsticks),
+        detector: getDetectorUniqueKey(DETECTORS.eating_with_chopsticks),
         number: '1'
       },
       toPass: {
@@ -3322,7 +3322,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Are you at a library?',
       notificationText: 'Share an experience with others who are also at the library',
       situation: {
-        detector: getDetectorId(DETECTORS.library),
+        detector: getDetectorUniqueKey(DETECTORS.library),
         number: '1'
       },
       toPass: {
@@ -3352,7 +3352,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Are you at a park?',
       notificationText: 'Share an experience with others who are also at a park',
       situation: {
-        detector: getDetectorId(DETECTORS.forest),
+        detector: getDetectorUniqueKey(DETECTORS.forest),
         number: '1'
       },
       toPass: {
@@ -3382,7 +3382,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Are you outside while its raining?',
       notificationText: 'Share an experience with others who are enjoying or enduring the rain',
       situation: {
-        detector: getDetectorId(DETECTORS.rainy),
+        detector: getDetectorUniqueKey(DETECTORS.rainy),
         number: '1'
       },
       toPass: {
@@ -3412,7 +3412,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Inside a coffee shop?',
       notificationText: 'Share an experience with others who are also at a coffee shop',
       situation: {
-        detector: getDetectorId(DETECTORS.coffee), // any place that has cups (cafes + bars + restaurants)
+        detector: getDetectorUniqueKey(DETECTORS.coffee), // any place that has cups (cafes + bars + restaurants)
         number: '1'
       },
       toPass: {
@@ -3440,7 +3440,7 @@ let CHI20_DTR_EXPERIENCES =  {
       notificationSubject: 'Eating at a restaurant?',
       notificationText: 'Share an experience with others who are enjoying big bites of their meal',
       situation: {
-        detector: getDetectorId(DETECTORS.big_bite_restaurant),
+        detector: getDetectorUniqueKey(DETECTORS.big_bite_restaurant),
         number: '1'
       },
       toPass: {
@@ -3472,7 +3472,7 @@ let CHI20_Olin_EXPERIENCES =  {
       // needName MUST have structure "My Need Name XYZ"
       needName: 'Hand Silhouette 1',
       situation: {
-        detector: getDetectorId(DETECTORS.sunny),
+        detector: getDetectorUniqueKey(DETECTORS.sunny),
         number: '1'
       },
       toPass: {
@@ -3502,7 +3502,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Inside a grocery store?',
       notificationText: 'Share an experience with others who are also grocery shopping',
       situation: {
-        detector: getDetectorId(DETECTORS.grocery),
+        detector: getDetectorUniqueKey(DETECTORS.grocery),
         number: '1'
       },
       toPass: {
@@ -3532,7 +3532,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Drinking at a bar?',
       notificationText: 'Share an experience with others who are also drinking at a bar',
       situation: {
-        detector: getDetectorId(DETECTORS.bar),
+        detector: getDetectorUniqueKey(DETECTORS.bar),
         number: '1'
       },
       toPass: {
@@ -3562,7 +3562,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Visiting a place of worship?',
       notificationText: 'Share an experience with others who are also visiting a place of worship',
       situation: {
-        detector: getDetectorId(DETECTORS.castle),
+        detector: getDetectorUniqueKey(DETECTORS.castle),
         number: '1'
       },
       toPass: {
@@ -3592,7 +3592,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Can you see the sunset?',
       notificationText: 'Share an experience with others who are also watching the sunset',
       situation: {
-        detector: getDetectorId(DETECTORS.sunset),
+        detector: getDetectorUniqueKey(DETECTORS.sunset),
         number: '1'
       },
       toPass: {
@@ -3622,7 +3622,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Eating at an asian restaurant?',
       notificationText: 'Share an experience with others who are also eating asian food',
       situation: {
-        detector: getDetectorId(DETECTORS.eating_with_chopsticks),
+        detector: getDetectorUniqueKey(DETECTORS.eating_with_chopsticks),
         number: '1'
       },
       toPass: {
@@ -3652,7 +3652,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Are you at a library?',
       notificationText: 'Share an experience with others who are also at the library',
       situation: {
-        detector: getDetectorId(DETECTORS.library),
+        detector: getDetectorUniqueKey(DETECTORS.library),
         number: '1'
       },
       toPass: {
@@ -3682,7 +3682,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Are you at a park?',
       notificationText: 'Share an experience with others who are also at a park',
       situation: {
-        detector: getDetectorId(DETECTORS.forest),
+        detector: getDetectorUniqueKey(DETECTORS.forest),
         number: '1'
       },
       toPass: {
@@ -3712,7 +3712,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Are you outside while its raining?',
       notificationText: 'Share an experience with others who are enjoying or enduring the rain',
       situation: {
-        detector: getDetectorId(DETECTORS.rainy),
+        detector: getDetectorUniqueKey(DETECTORS.rainy),
         number: '1'
       },
       toPass: {
@@ -3742,7 +3742,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Inside a coffee shop?',
       notificationText: 'Share an experience with others who are also at a coffee shop',
       situation: {
-        detector: getDetectorId(DETECTORS.coffee), // any place that has cups (cafes + bars + restaurants)
+        detector: getDetectorUniqueKey(DETECTORS.coffee), // any place that has cups (cafes + bars + restaurants)
         number: '1'
       },
       toPass: {
@@ -3770,7 +3770,7 @@ let CHI20_Olin_EXPERIENCES =  {
       notificationSubject: 'Eating at a restaurant?',
       notificationText: 'Share an experience with others who are enjoying big bites of their meal',
       situation: {
-        detector: getDetectorId(DETECTORS.big_bite_restaurant),
+        detector: getDetectorUniqueKey(DETECTORS.big_bite_restaurant),
         number: '1'
       },
       toPass: {

--- a/imports/api/UserMonitor/detectors/detectors.js
+++ b/imports/api/UserMonitor/detectors/detectors.js
@@ -1,3 +1,34 @@
 import { Mongo } from 'meteor/mongo';
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { Schema } from '../../schema.js';
 
 export const Detectors = new Mongo.Collection('detectors');
+
+/**
+{
+    "_id": "mS8qJtDnrAzB8L57B",
+    "description": "clear knowsDTR",
+    "rules": [
+        "(knowsDTR && ((clear && daytime)));"
+    ],
+    "variables": [
+        "var clear;",
+        "var daytime;",
+        "var knowsDTR;"
+    ]
+}
+ */
+Schema.Detectors = new SimpleSchema({
+    description: {
+        type: String,
+        unique: true
+    },
+    rules: {
+        type: [String]
+    },
+    variables: {
+        type: [String]
+    }
+});
+
+Detectors.attachSchema(Schema.Detectors);

--- a/imports/api/UserMonitor/detectors/detectors.tests.js
+++ b/imports/api/UserMonitor/detectors/detectors.tests.js
@@ -1,17 +1,14 @@
 import { resetDatabase } from 'meteor/xolvio:cleaner';
-import {
-  matchAffordancesWithDetector,
-  matchLocationWithDetector
-}
-  from './methods';
 import { Detectors } from './detectors';
 import { getPlaceKeys, onePlaceNotThesePlacesSets,
-         placeSubsetAffordances, flattenAffordanceDict} from './methods'
+         placeSubsetAffordances, flattenAffordanceDict, 
+         matchAffordancesWithDetector, getDetectorId
+       } from './methods'
 import { CONSTANTS } from "../../Testing/testingconstants";
 
 
 describe('Small Detector Tests', function () {
-  let detectorId = CONSTANTS.DETECTORS.produce._id;
+  let detectorId = getDetectorId(CONSTANTS.DETECTORS.produce);
 
   beforeEach(function () {
     resetDatabase();
@@ -83,9 +80,9 @@ describe('Detectors in testingcontants.js are valid', function() {
 
     _.forEach(allDetectors, (detector) => {
       try {
-        matchAffordancesWithDetector(affordances, detector._id);
+        matchAffordancesWithDetector(affordances, getDetectorId(detector));
       } catch(err) {
-        console.error(`Detector failed to compile with id (${detector._id}) and description (${detector.description})`)
+        console.error(`Detector failed to compile detector with identifying description (${detector.description})`);
         throw(err);
       }
     });

--- a/imports/api/UserMonitor/detectors/detectors.tests.js
+++ b/imports/api/UserMonitor/detectors/detectors.tests.js
@@ -1,14 +1,14 @@
 import { resetDatabase } from 'meteor/xolvio:cleaner';
 import { Detectors } from './detectors';
 import { getPlaceKeys, onePlaceNotThesePlacesSets,
-         placeSubsetAffordances, flattenAffordanceDict, 
-         matchAffordancesWithDetector, getDetectorId
+         placeSubsetAffordances, flattenAffordanceDict,
+         matchAffordancesWithDetector, getDetectorUniqueKey
        } from './methods'
 import { CONSTANTS } from "../../Testing/testingconstants";
 
 
 describe('Small Detector Tests', function () {
-  let detectorId = getDetectorId(CONSTANTS.DETECTORS.produce);
+  let detectorUniqueKey = getDetectorUniqueKey(CONSTANTS.DETECTORS.produce);
 
   beforeEach(function () {
     resetDatabase();
@@ -21,7 +21,7 @@ describe('Small Detector Tests', function () {
       'grocery': true
     };
 
-    if (!matchAffordancesWithDetector(affordances, detectorId)) {
+    if (!matchAffordancesWithDetector(affordances, detectorUniqueKey)) {
       chai.assert(false);
     }
   });
@@ -31,7 +31,7 @@ describe('Small Detector Tests', function () {
       'coffee': true
     };
 
-    if (matchAffordancesWithDetector(affordances, detectorId)) {
+    if (matchAffordancesWithDetector(affordances, detectorUniqueKey)) {
       chai.assert(false);
     }
   });
@@ -41,7 +41,7 @@ describe('Small Detector Tests', function () {
   //   let lat = 42.047621;
   //   let lng = -87.679488;
   //
-  //   matchLocationWithDetector(lat, lng, detectorId, function(doesUserMatchSituation) {
+  //   matchLocationWithDetector(lat, lng, detectorUniqueKey, function(doesUserMatchSituation) {
   //     if (!doesUserMatchSituation) {
   //       chai.assert(false);
   //     }
@@ -53,7 +53,7 @@ describe('Small Detector Tests', function () {
   //   let lat = 42.056838;
   //   let lng = -87.675940;
   //
-  //   matchLocationWithDetector(lat, lng, detectorId, function(doesUserMatchSituation) {
+  //   matchLocationWithDetector(lat, lng, detectorUniqueKey, function(doesUserMatchSituation) {
   //     if (doesUserMatchSituation) {
   //       chai.assert(false);
   //     }
@@ -80,7 +80,7 @@ describe('Detectors in testingcontants.js are valid', function() {
 
     _.forEach(allDetectors, (detector) => {
       try {
-        matchAffordancesWithDetector(affordances, getDetectorId(detector));
+        matchAffordancesWithDetector(affordances, getDetectorUniqueKey(detector));
       } catch(err) {
         console.error(`Detector failed to compile detector with identifying description (${detector.description})`);
         throw(err);

--- a/imports/api/UserMonitor/detectors/methods.js
+++ b/imports/api/UserMonitor/detectors/methods.js
@@ -141,20 +141,20 @@ export const flattenAffordanceDict = function(nestedAff) {
   return flatDict;
 };
 
-export const getDetectorId = (detector) => {
+export const getDetectorUniqueKey = (detector) => {
   return detector.description;
 };
 
 /**
  * Attempts to match affordances with a detector
  * @param {Object} affordances  key value pairs of { userAffordances: values }
- * @param {String} detectorId detector to attempt matching for
+ * @param {String} detectorUniqueKey detector to attempt matching for
  * @returns {Boolean} whether affordances match detector
  */
-export const matchAffordancesWithDetector = function (affordances, detectorId) {
-  const detector = Detectors.findOne({ description : detectorId });
+export const matchAffordancesWithDetector = function (affordances, detectorUniqueKey) {
+  const detector = Detectors.findOne({ description : detectorUniqueKey });
 
-  // check if no detector for detectorId exists, otherwise attempt to match affordances to detector
+  // check if no detector for detectorUniqueKey exists, otherwise attempt to match affordances to detector
   if (typeof detector === 'undefined') {
     return false;
   }

--- a/imports/api/UserMonitor/detectors/methods.js
+++ b/imports/api/UserMonitor/detectors/methods.js
@@ -141,6 +141,10 @@ export const flattenAffordanceDict = function(nestedAff) {
   return flatDict;
 };
 
+export const getDetectorId = (detector) => {
+  return detector.description;
+};
+
 /**
  * Attempts to match affordances with a detector
  * @param {Object} affordances  key value pairs of { userAffordances: values }
@@ -148,7 +152,7 @@ export const flattenAffordanceDict = function(nestedAff) {
  * @returns {Boolean} whether affordances match detector
  */
 export const matchAffordancesWithDetector = function (affordances, detectorId) {
-  const detector = Detectors.findOne({ _id: detectorId });
+  const detector = Detectors.findOne({ description : detectorId });
 
   // check if no detector for detectorId exists, otherwise attempt to match affordances to detector
   if (typeof detector === 'undefined') {

--- a/imports/api/UserMonitor/detectors/server/publications.js
+++ b/imports/api/UserMonitor/detectors/server/publications.js
@@ -7,5 +7,5 @@ Meteor.publish('detectors', function () {
 });
 
 Meteor.publish('detectors.byId', function (detectorId) {
-  return Detectors.find({ _id: detectorId });
+  return Detectors.find({ description: detectorId });
 });

--- a/imports/api/UserMonitor/detectors/server/publications.js
+++ b/imports/api/UserMonitor/detectors/server/publications.js
@@ -6,6 +6,6 @@ Meteor.publish('detectors', function () {
   return Detectors.find();
 });
 
-Meteor.publish('detectors.byId', function (detectorId) {
-  return Detectors.find({ description: detectorId });
+Meteor.publish('detectors.byId', function (detectorUniqueKey) {
+  return Detectors.find({ description: detectorUniqueKey });
 });

--- a/imports/startup/client/router.js
+++ b/imports/startup/client/router.js
@@ -72,7 +72,7 @@ Router.route('affordances', {
 });
 
 Router.route('api.custom.dynamic', {
-  path: '/apicustomdynamic/:iid/:detectorId',
+  path: '/apicustomdynamic/:iid/:detectorUniqueKey',
   template: 'dynamicParticipate',
   before: function() {
     this.next();

--- a/imports/ui/components/active_experience.html
+++ b/imports/ui/components/active_experience.html
@@ -14,7 +14,7 @@
                 </a> -->
             </div>
             <div class="card-action">
-              <a href="/apicustomdynamic/{{iid}}/{{detectorId}}/">PARTICIPATE</a>
+              <a href="/apicustomdynamic/{{iid}}/{{detectorUniqueKey}}/">PARTICIPATE</a>
             </div>
         </div>
     </div>

--- a/imports/ui/components/active_experience.js
+++ b/imports/ui/components/active_experience.js
@@ -22,7 +22,7 @@ Template.activeExperience.events({
         params: {
           iid: this.iid,
           eid: this.experience._id,
-          detectorId: this.detectorId
+          detectorUniqueKey: this.detectorUniqueKey
         }
       };
       Meteor.call('insertLog', dic);

--- a/imports/ui/pages/dynamic_participate.js
+++ b/imports/ui/pages/dynamic_participate.js
@@ -19,7 +19,7 @@ Template.dynamicParticipate.onCreated(function() {
     return;
   }
   this.iid = Router.current().params.iid;
-  this.detectorId = Router.current().params.detectorId;
+  this.detectorUniqueKey = Router.current().params.detectorUniqueKey;
   const handles = [
     this.subscribe('incidents.single', this.iid),
     this.subscribe('assignments.single', this.iid),
@@ -44,7 +44,7 @@ Template.dynamicParticipate.onCreated(function() {
       this.assignment = Assignments.findOne();
       let needNamesBinnedByDetector = needAggregator(this.incident);
 
-      let potentialNeedNames = needNamesBinnedByDetector[this.detectorId];
+      let potentialNeedNames = needNamesBinnedByDetector[this.detectorUniqueKey];
 
       // TODO: filter additionally by only the needs in which this user is assigned to
       /**

--- a/imports/ui/pages/home.js
+++ b/imports/ui/pages/home.js
@@ -36,7 +36,7 @@ Template.home.events({
 Template.home.helpers({
   activeUserAssigment() {
     if (Template.instance().subscriptionsReady()) {
-      // create [{iid: incident_id, experience: experience, detectorId: detector_id}]
+      // create [{iid: incident_id, experience: experience, detectorUniqueKey: detector_id}]
       let activeAssignments = Assignments.find().fetch();
       let output = [];
 
@@ -55,7 +55,7 @@ Template.home.helpers({
           }
         });
 
-        _.forEach(needNamesBinnedByDetector, (needNamesForDetector, detectorId) => {
+        _.forEach(needNamesBinnedByDetector, (needNamesForDetector, detectorUniqueKey) => {
           let assignedNeedNamesForDetector = setIntersection(assignedNeedNames, needNamesForDetector);
           if (assignedNeedNamesForDetector.length === 0) {
             // user not assigned to any needs for this detector
@@ -69,7 +69,7 @@ Template.home.helpers({
           output.push({
             'iid': assignment._id,
             'experience': experience,
-            'detectorId': detectorId
+            'detectorUniqueKey': detectorUniqueKey
           });
 
         });

--- a/simulatelocations.py
+++ b/simulatelocations.py
@@ -22,19 +22,19 @@ def followPath(path, uid):
         time.sleep(1)
 
 def setLocation(location, uid):
-    host = "http://localhost:3000"
+    host = "http://localhost:3000" 
     # host = "https://ce-platform.herokuapp.com"
     # host = "https://staging-ce-platform.herokuapp.com"
     r = requests.post(host + "/api/geolocation", json={
-                "userId": uid,
-                "location": {
-                    "coords": {
-                        "latitude": location[0],
-                        "longitude": location[1]
-                    },
-                    "activity": {"type": "unknown", "confidence": 100}
-                }
-            })
+        "userId": uid,
+        "location": {
+            "coords": {
+                "latitude": location[0],
+                "longitude": location[1]
+            },
+            "activity": {"type": "unknown", "confidence": 100}
+        }
+    })
     #print(uid + "at location " + str(location[0]) + " " + str(location[1]))
 
 
@@ -222,7 +222,6 @@ def allUsersAtBars():
     setLocation(bars, sys.argv[3])
     setLocation(bars, sys.argv[4])
     setLocation(bars, sys.argv[5])
-
     print("all users at bar")
 
 def allUsersAtTrain():


### PR DESCRIPTION
Summary: Previously detectors were linked by `_id`. This caused problems in deployment, when `_id` set within javascript would be different than the `_id` set within MongoDB. Now, we use `description` as the unique key 

In code, we'll refer to this as the `detectorUniqueKey` and `getDetectorUniqueKey`

Testing:
People are being notified!
<img width="321" alt="image" src="https://user-images.githubusercontent.com/5459644/75275802-adda5a00-57ca-11ea-85d8-1cf96cc3a1c6.png">
