### PR TITLE
Fixes connection with Mongo Atlas

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -58,3 +58,4 @@ useraccounts:bootstrap
 underscore@1.0.10
 fortawesome:fontawesome
 dburles:collection-helpers
+meanware:gridfs

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -90,6 +90,7 @@ localstorage@1.2.0
 logging@1.1.20
 mdg:validated-method@1.2.0
 mdg:validation-error@0.5.1
+meanware:gridfs@0.1.1
 meteor@1.9.3
 meteor-base@1.4.0
 meteortoys:toykit@3.0.4


### PR DESCRIPTION
Summary: Fixes #131. Apparently, `cfs:gridfs` is outdated for MongoDB 3.4
atlas. Adding this forked package `meanware:gridfs` solved my driver
issues.

Source: https://forums.meteor.com/t/solved-meteor-1-7-0-3-cant-connect-to-mongo-atlas-hosted-aws/44173

Tests: 
local test via
```MONGO_URL="<INSERT-ATLAS-MONGO-URI>" meteor``` worked
